### PR TITLE
Fix Digital Glue link

### DIFF
--- a/src/layouts/CustomerFooter.tsx
+++ b/src/layouts/CustomerFooter.tsx
@@ -21,7 +21,7 @@ export function CustomerFooter() {
       }}>
         Made by{' '}
         <a
-          href="https://digitalglue.co"
+          href="https://digitalglue.dev"
           target="_blank"
           rel="noopener noreferrer"
           style={{


### PR DESCRIPTION
## Summary
- Update footer link from `digitalglue.co` → `digitalglue.dev`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)