### PR TITLE
Fix quick order links to navigate to /orders/new

### DIFF
--- a/src/app/pages/home/components/BottomNavigation.v2.tsx
+++ b/src/app/pages/home/components/BottomNavigation.v2.tsx
@@ -144,7 +144,7 @@ export function BottomNavigationV2() {
           </a>
 
           {/* Quick Order - Matches header button style */}
-          <a href="#quick-order" style={{
+          <a href="/orders/new" style={{
             display: 'inline-flex',
             alignItems: 'center',
             padding: 'var(--space-xs) var(--space-md)',

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -62,7 +62,7 @@ export function Header({
           <span className="unified-header__logo-text">Evan's Fresh Catch</span>
         </a>
         <div className="unified-header__actions">
-          <a href="#quick-order" className="quick-order-button">
+          <a href="/orders/new" className="quick-order-button">
             + Quick Order
           </a>
           <UserMenu user={user} currentOrganization={currentOrganization} />


### PR DESCRIPTION
## Summary
- Header and bottom nav "Quick Order" buttons used `#quick-order` anchors (dead links)
- Updated both to navigate to `/orders/new`

## Test plan
- [ ] Click "Quick Order" in header → goes to /orders/new
- [ ] Click "Quick Order" in bottom nav → goes to /orders/new

🤖 Generated with [Claude Code](https://claude.com/claude-code)