### PR TITLE
fix(chat): close authz holes in createConversation + saveCustomerEmail

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -9,4 +9,4 @@ export { fetchVendorData, getQuickActions } from "./pages/home/fetchVendorData";
 
 export { validateCsrfToken } from "@/session/store";
 
-export { saveCustomerEmail } from "@/chat/functions";
+export { saveCustomerEmail, createConversation } from "@/chat/functions";

--- a/src/app/pages/home/components/NamePrompt.tsx
+++ b/src/app/pages/home/components/NamePrompt.tsx
@@ -64,7 +64,12 @@ export function NamePrompt({
         storeConversationId(organizationId, result.conversationId);
         onConversationCreated(result.conversationId);
       } catch {
-        if (!cancelled) setError("Failed to start chat. Please try again.");
+        // Collapse all failure modes (rate-limited / invalid vendor) into one
+        // generic message — naming the specific reason would leak whether an
+        // org id is a valid vendor.
+        if (!cancelled) {
+          setError("Couldn't start the chat. Please wait a moment and try again.");
+        }
       }
     }
 
@@ -90,7 +95,9 @@ export function NamePrompt({
         storeConversationId(organizationId, result.conversationId);
         onConversationCreated(result.conversationId);
       } catch {
-        setError("Failed to start chat. Please try again.");
+        // Same deliberate generic message as the auto-create path — don't leak
+        // which server check failed (rate limit vs invalid vendor).
+        setError("Couldn't start the chat. Please wait a moment and try again.");
         setSubmitting(false);
       }
     },

--- a/src/app/test-utils.ts
+++ b/src/app/test-utils.ts
@@ -22,6 +22,13 @@ export async function seedBusinessOrg(name: string) {
   });
 }
 
+export async function seedIndividualOrg(name: string) {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  return db.organization.create({
+    data: { name, slug, type: "individual" },
+  });
+}
+
 export async function seedUser(email: string) {
   return db.user.create({
     data: { username: email, email },
@@ -96,6 +103,15 @@ export async function seedConversation(organizationId: string, customerId: strin
 export async function getConversationCustomer(id: string) {
   const c = await db.conversation.findUnique({ where: { id } });
   return c?.customerId ?? null;
+}
+
+export async function getConversationEmail(id: string) {
+  const c = await db.conversation.findUnique({ where: { id } });
+  return c?.customerEmail ?? null;
+}
+
+export async function countConversationsForOrg(organizationId: string) {
+  return db.conversation.count({ where: { organizationId } });
 }
 
 // --- Order seeding / admin-query mirror ------------------------------------

--- a/src/chat/chat-authz.test.ts
+++ b/src/chat/chat-authz.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, afterAll } from "vitest";
+import { vitestInvoke } from "rwsdk-community/test";
+
+// Auth/ownership tests for the chat security holes closed in functions.ts:
+//   - saveCustomerEmail: ownership check on claimed conversations
+//   - createConversation: org must exist AND be a "business" (vendor) org
+//
+// The test bridge runs these with an empty ctx (no session/user), i.e. as an
+// anonymous caller — exactly the untrusted client the checks defend against.
+
+const orgIds: string[] = [];
+const userIds: string[] = [];
+
+afterAll(async () => {
+  for (const id of orgIds) await vitestInvoke("deleteOrgCascade", id);
+  await vitestInvoke("deleteUsers", userIds);
+});
+
+type SaveResult = { success: boolean; error?: string };
+
+describe("saveCustomerEmail authorization", () => {
+  it("rejects writing a claimed conversation from an unauthenticated caller", async () => {
+    const org = await vitestInvoke<{ id: string }>("seedBusinessOrg", `authz-${crypto.randomUUID()}`);
+    orgIds.push(org.id);
+    const owner = await vitestInvoke<{ id: string }>("seedUser", `owner-${crypto.randomUUID()}@x.com`);
+    userIds.push(owner.id);
+
+    // Conversation already claimed by `owner`.
+    const conv = await vitestInvoke<{ id: string }>("seedConversation", org.id, owner.id);
+
+    const r = await vitestInvoke<SaveResult>("saveCustomerEmail", conv.id, "attacker@evil.com");
+
+    expect(r.success).toBe(false);
+    // Owned conversation is untouched — email never written.
+    expect(await vitestInvoke("getConversationEmail", conv.id)).toBeNull();
+  });
+
+  it("allows saving on an anonymous conversation (UUID-as-bearer path)", async () => {
+    const org = await vitestInvoke<{ id: string }>("seedBusinessOrg", `authz-${crypto.randomUUID()}`);
+    orgIds.push(org.id);
+
+    const conv = await vitestInvoke<{ id: string }>("seedConversation", org.id, null);
+
+    const r = await vitestInvoke<SaveResult>("saveCustomerEmail", conv.id, "customer@example.com");
+
+    expect(r).toEqual({ success: true });
+    expect(await vitestInvoke("getConversationEmail", conv.id)).toBe("customer@example.com");
+  });
+});
+
+describe("createConversation vendor validation", () => {
+  it("rejects a nonexistent organizationId", async () => {
+    await expect(
+      vitestInvoke("createConversation", {
+        customerName: "Mallory",
+        organizationId: crypto.randomUUID(),
+      }),
+    ).rejects.toThrow("Invalid vendor");
+  });
+
+  it("rejects a non-business (individual) organizationId and creates nothing", async () => {
+    const indiv = await vitestInvoke<{ id: string }>("seedIndividualOrg", `indiv-${crypto.randomUUID()}`);
+    orgIds.push(indiv.id);
+
+    await expect(
+      vitestInvoke("createConversation", {
+        customerName: "Mallory",
+        organizationId: indiv.id,
+      }),
+    ).rejects.toThrow("Invalid vendor");
+
+    expect(await vitestInvoke<number>("countConversationsForOrg", indiv.id)).toBe(0);
+  });
+
+  it("creates an anonymous conversation for a valid business org", async () => {
+    const org = await vitestInvoke<{ id: string }>("seedBusinessOrg", `authz-${crypto.randomUUID()}`);
+    orgIds.push(org.id);
+
+    const result = await vitestInvoke<{ conversationId: string }>("createConversation", {
+      customerName: "Ada",
+      organizationId: org.id,
+    });
+
+    expect(typeof result.conversationId).toBe("string");
+    // Bridge caller is unauthenticated, so the conversation is anonymous.
+    expect(await vitestInvoke("getConversationCustomer", result.conversationId)).toBeNull();
+  });
+});

--- a/src/chat/functions.ts
+++ b/src/chat/functions.ts
@@ -6,6 +6,7 @@ import { db } from "@/db";
 import { hasAdminAccess } from "@/utils/permissions";
 import { requireCsrf } from "@/session/csrf";
 import { claimConversationsForUser } from "@/chat/claims";
+import { checkRateLimit } from "@/rate-limit/middleware";
 
 function notifyInbox(organizationId: string): void {
   try {
@@ -24,13 +25,31 @@ export async function createConversation({
   organizationId: string;
 }) {
   const { ctx } = requestInfo;
+
+  // Rate limit anonymous conversation creation per IP to blunt spam/abuse.
+  const rl = await checkRateLimit("chatCreate");
+  if (!rl.allowed) {
+    throw new Error("Too many attempts. Please try again later.");
+  }
+
+  // Validate the target org exists AND is a vendor (business) org. The client
+  // supplies organizationId, so without this a forged/nonexistent id could
+  // create orphan conversations or attach one to an individual/customer org.
+  const org = await db.organization.findUnique({
+    where: { id: organizationId },
+    select: { id: true, type: true },
+  });
+  if (!org || org.type !== "business") {
+    throw new Error("Invalid vendor");
+  }
+
   const customerId = ctx.user?.id ?? null;
 
   const conversation = await db.conversation.create({
     data: {
       customerName,
       customerPhone,
-      organizationId,
+      organizationId: org.id,
       customerId,
     },
   });
@@ -252,9 +271,17 @@ export async function saveCustomerEmail(
   conversationId: string,
   email: string,
 ) {
+  const { ctx } = requestInfo;
+
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(email)) {
+  if (typeof email !== "string" || email.length > 254 || !emailRegex.test(email)) {
     return { success: false, error: "Invalid email format" };
+  }
+
+  // Rate limit per IP — this endpoint takes an arbitrary conversationId.
+  const rl = await checkRateLimit("chatEmail");
+  if (!rl.allowed) {
+    return { success: false, error: "Too many attempts. Try again later." };
   }
 
   const conversation = await db.conversation.findUnique({
@@ -262,6 +289,18 @@ export async function saveCustomerEmail(
   });
 
   if (!conversation) {
+    return { success: false, error: "Conversation not found" };
+  }
+
+  // Auth: anonymous conversations (customerId=null) use the conversation ID as
+  // a bearer token — knowing the UUID is proof enough. A claimed conversation
+  // (customerId set) may only be written by its owner or a member of the vendor
+  // org. Mirrors the check in getMessages/getConversation/markAsRead. Without
+  // this, anyone holding the UUID could overwrite a claimed customer's email.
+  const isAnonymous = conversation.customerId === null;
+  const isOwner = conversation.customerId !== null && conversation.customerId === ctx.user?.id;
+  const isOrgMember = conversation.organizationId === ctx.currentOrganization?.id;
+  if (!isAnonymous && !isOwner && !isOrgMember) {
     return { success: false, error: "Conversation not found" };
   }
 

--- a/src/chat/functions.ts
+++ b/src/chat/functions.ts
@@ -32,9 +32,11 @@ export async function createConversation({
     throw new Error("Too many attempts. Please try again later.");
   }
 
-  // Validate the target org exists AND is a vendor (business) org. The client
-  // supplies organizationId, so without this a forged/nonexistent id could
-  // create orphan conversations or attach one to an individual/customer org.
+  // The client supplies organizationId, so validate it points at a real vendor
+  // (business) org before creating. The type check is the primary guard — it
+  // stops a forged id from attaching a conversation to an individual/customer
+  // org; the existence check also rejects unknown ids, since D1 doesn't
+  // guarantee FK enforcement at runtime.
   const org = await db.organization.findUnique({
     where: { id: organizationId },
     select: { id: true, type: true },

--- a/src/rate-limit/durableObject.ts
+++ b/src/rate-limit/durableObject.ts
@@ -2,8 +2,10 @@ import { DurableObject } from "cloudflare:workers";
 
 // Configurable limits per endpoint
 const ENDPOINT_LIMITS: Record<string, { maxRequests: number; windowMs: number }> = {
-  otpSend: { maxRequests: 3, windowMs: 15 * 60 * 1000 },     // 3 per 15min
-  otpVerify: { maxRequests: 10, windowMs: 15 * 60 * 1000 },   // 10 per 15min
+  otpSend: { maxRequests: 3, windowMs: 15 * 60 * 1000 },       // 3 per 15min
+  otpVerify: { maxRequests: 10, windowMs: 15 * 60 * 1000 },     // 10 per 15min
+  chatCreate: { maxRequests: 15, windowMs: 10 * 60 * 1000 },    // 15 new conversations per 10min per IP
+  chatEmail: { maxRequests: 20, windowMs: 15 * 60 * 1000 },     // 20 email saves per 15min per IP
 };
 
 const DEFAULT_LIMIT = { maxRequests: 20, windowMs: 15 * 60 * 1000 };


### PR DESCRIPTION
## What

Closes the two chat authz holes in `src/chat/functions.ts` (bead `fresh-catch-6q4m4`).

- **`saveCustomerEmail`** had **zero auth** — any holder of a conversation UUID could write `customerEmail` on it, including on *claimed* (account-owned) conversations. Now: email format/length guard → per-IP rate limit (`chatEmail`) → ownership gate (`isAnonymous || isOwner || isOrgMember`, the same gate already used by `getMessages`/`getConversation`/`markAsRead`). Anonymous/unclaimed conversations still write (funnel intact); claimed ones are no longer writable by a bare UUID.
- **`createConversation`** trusted the client-supplied `organizationId`. Now: per-IP rate limit (`chatCreate`) → the org must exist **and** be `type === "business"`, else `"Invalid vendor"`. The validated `org.id` is what gets written.
- **Rate limits** added to the existing `RateLimitDurableObject`: `chatCreate` 15/10min, `chatEmail` 20/15min, per-IP (additive, reuses the OTP limiter).

## Design decision (accepted: Option A)

The conversation-UUID-as-bearer model is **kept** — bearer + rate limits + ownership gate on claimed conversations. This preserves the frictionless anonymous chat funnel. Option B (require auth) was rejected (kills the funnel). Option C (server-issued httpOnly capability) is filed as a deferred backlog bead (`fresh-catch-wn472`) — not scheduled.

## Tests

`src/chat/chat-authz.test.ts` (5 tests, via the `/_test` bridge exercising real production code paths):
- unauthenticated `saveCustomerEmail` on a claimed conversation is rejected (email stays null);
- anonymous/unclaimed write still succeeds (funnel preserved);
- `createConversation` rejects nonexistent org and non-business org (`"Invalid vendor"`, no row created);
- happy path still creates.

## Verification

- Independent medium-effort review: no critical/major findings; the two nits raised (imprecise comment; client error-message consistency) are addressed in the final commit.
- `pnpm run types` clean; `pnpm test` → 8 files / 30 tests pass.
- No schema/migration changes; diff is confined to `src/chat/functions.ts`, `src/rate-limit/durableObject.ts`, `src/app/actions.ts`, `src/app/test-utils.ts`, `src/chat/chat-authz.test.ts`, and a client copy/comment tweak in `NamePrompt.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
