### PR TITLE
UX quick wins: fix dead controls, add navigation feedback, align header

### DIFF
--- a/docs/design-audit/2026-07-20-ux-field-review.md
+++ b/docs/design-audit/2026-07-20-ux-field-review.md
@@ -1,0 +1,135 @@
+# UX Field Review — Customer Home & Order Flow
+
+**Date:** 2026-07-20
+**Source:** Founder walkthrough of the live app (market.digitalglue.dev) as a signed-out / customer user
+**Scope:** Diagnosis only — no code changes. Each observation is traced to its root cause in code, with the concept for a fix. Items are tagged **Quick Win** (small, isolated change) or **Overhaul** (belongs in the larger design pass, see bottom).
+
+---
+
+## 1. Blue schedule text in All Markets rows looks like a link — and hides the real tap target
+
+**Observation:** In the All Markets list, the blue time entry ("Sat 8am–12pm") looks tappable, and it's scary to tap. Meanwhile the actual affordance — tap the row to expand market details — is invisible. The builder knows the row is tappable; a user doesn't.
+
+**Root cause:** Two reinforcing problems in `src/app/pages/home/components/CompactMarketRow.tsx`:
+
+- The schedule is styled `color: var(--color-action-primary)` at `CompactMarketRow.tsx:90` — the same ocean blue used for buttons and links app-wide. In a design system, the action color is a promise ("this does something"). Using it as a data highlight breaks that promise. Same pattern in `MarketCard.tsx:81`.
+- The row itself (`CompactMarketRow.tsx:48-67`) has correct semantics (`role="button"`, `aria-expanded`, keyboard handling — nicely done) but **zero visual affordance**: no background change on press, no hint text, and the only signal is a small tertiary-gray `›` chevron at the far right, after the star. A 60+ user scanning outdoors in sunlight will never infer "tap anywhere on this row."
+
+**Concept:**
+- Schedule text → neutral (`--color-text-primary` or `--color-text-secondary`, keep the semibold weight for scanability). Reserve blue strictly for actions. **Quick Win**
+- Give the row a visible affordance: chevron pointing **down** when collapsed (the `›`-rotates-to-`˅` convention reads as "navigates away" when sideways), an active/pressed background state (`:active { background: var(--color-surface-secondary) }`), and/or an explicit "Details" label next to the chevron. For this audience, explicit beats subtle — a small "Details ˅" text button communicates more than any amount of styling. **Quick Win** for the states; label/layout tweaks could ride with the overhaul.
+
+---
+
+## 2. Hero quick actions: "Markets" and "Contact" buttons do nothing
+
+**Observation:** The big icon buttons in the hero — the marketing/contact ones — are dead. Order and My Orders work.
+
+**Root cause:** `src/app/pages/home/fetchVendorData.ts:5-13`:
+
+```ts
+{ icon: "🐟", title: "Order", href: orderHref },        // real route ✓
+{ icon: "📋", title: "My Orders", href: "/orders" },    // real route ✓
+{ icon: "📍", title: "Markets", href: "#markets" },     // ✗ no element with id="markets" exists
+{ icon: "💬", title: "Contact", href: "#text" }         // ✗ no element with id="text" exists
+```
+
+Grep confirms no `id="markets"` or `id="text"` anywhere in `src/` — those anchors are pointing at nothing, so the browser silently no-ops. Same class of bug: the 📍 Directions buttons in both `MarketCard.tsx:154` and `CompactMarketRow.tsx:193` link to `#directions-{id}`, which also has no target anywhere. **Three dead affordances shipped to production**, all placeholder hrefs that were never wired up.
+
+**Note:** This hero (`FreshHero`) only renders when there's no live catch data — when a catch update is live, `FreshSheet` renders instead (`CustomerHomeUI.tsx:113-117`), which has no quick actions at all. So the dead buttons show precisely in the "empty" state where a new visitor lands.
+
+**Concept:**
+- "Markets": add `id="markets"` to the All Markets section and smooth-scroll, or drop the button. **Quick Win**
+- "Contact": wire to the chat sheet (the working chat in the bottom nav), an `sms:`/`tel:` link to the vendor, or drop it. Needs a product decision on what "Contact" means. **Quick Win once decided**
+- "Directions": either build the maps handoff (`https://maps.google.com/?q=` + address — the Market model would need address data surfaced) or remove the pin buttons until it exists. A dead button is worse than no button. **Quick Win (remove) / small feature (wire up)**
+
+---
+
+## 3. Order / My Orders work, but with zero feedback — taps feel dead, then the page "races"
+
+**Observation:** Tap Order, nothing visibly happens, so you tap something else — then the new page lands and it feels like a race. No indication the button did anything, and honestly no strong indication it *is* a button.
+
+**Root cause:** This is the single biggest "web page, not web app" contributor, and it's structural:
+
+- Navigation is **full-page browser navigation**. `src/client.tsx` calls `initClient()` only — RWSDK's client navigation (`initClientNavigation()`) is not enabled. Every `<a href>` is a full document round-trip: server render, D1 queries (`fetchVendorData` runs 3 queries), possibly a Workers/D1 cold start.
+- The app is an installed PWA with `"display": "standalone"` (`public/manifest.json:5`) — so there's **no browser chrome, no URL bar spinner**. The one loading indicator the browser normally provides is hidden. Result: tap → 1–3 seconds of literally nothing → new page.
+- No button-level feedback either: the NavGrid cards (`design-system/components/NavGrid.tsx`) and nav links are plain anchors with hover transitions but no `:active`/pressed state and no in-flight state.
+
+**Concept (in order of leverage):**
+1. **Enable client navigation** (`initClientNavigation()` in `client.tsx`) so RSC-based transitions replace full reloads. This is the RWSDK 1.x intended pattern and the foundation for everything else. Needs testing across the auth/session/tenant middleware. **Overhaul — do first, it changes what else is needed**
+2. **Global navigation progress indicator** — a thin top progress bar (or overlay spinner) that appears the moment any navigation starts. With client nav this is a hook; without it, a small `document`-level click listener on same-origin links can still flip a "loading" class before the browser unloads. **Quick Win version possible now; proper version rides on #1**
+3. **Pressed states everywhere.** Every tappable element gets `:active` scale/color feedback (e.g. `transform: scale(0.97)` + background shift, `transition: 80ms`). Cheap, instant, and for older users the confirmation that "yes, you pressed it." Belongs in the design system as a shared `.pressable` behavior, not per-component. **Quick Win**
+4. Once #1 lands: disable/spinner the specific tapped control during the transition to prevent double-fire.
+
+---
+
+## 4. Mic button does nothing when signed out
+
+**Observation:** The microphone button on the fab bar doesn't do anything for a logged-out user. Chat works.
+
+**Root cause:** Confirmed bug, not perception. The mic button always renders (`BottomNavigation.tsx:196-217`) and calls `openCommandBar()`, which sets `commandBarOpen = true` in `CustomerLayoutClient`. But the `CommandBar` component is only mounted **inside `{user && (...)}`** at `CustomerLayoutClient.tsx:115-117`. Signed out: state flips, nothing is mounted, silent no-op.
+
+**Concept:** Pick one:
+- Hide the mic when `!user` (simplest, honest UI), or
+- Keep it and have it open the `AuthSheet` (`src/components/AuthSheet.tsx` already exists as the account-creation trigger for exactly this kind of host) — "Sign in to use voice ordering." Better funnel, slightly more work.
+Either way, a visible control must never silently no-op. **Quick Win**
+
+---
+
+## 5. Header on the order form: "+ Order" and "Sign In" buttons are mismatched sizes
+
+**Observation:** In the order form page header, the Order button is small, the Sign In button is bigger. Looks strange.
+
+**Root cause:** Two adjacent buttons styled in two different CSS files with different specs:
+
+| | `.order-button` (`Header.css:68-80, 142-146`) | `.sign-in-button` (`UserMenu.css:3-17`) |
+|---|---|---|
+| Vertical padding | `--space-xs` (mobile: xs too) | `--space-sm` |
+| Font size | `--text-sm` (mobile: `--text-xs`) | `--text-sm` (no mobile shrink) |
+| Radius | `--radius-full` (pill) | `--radius-md` (rounded rect) |
+| Background | coral gradient | blue gradient |
+
+So on mobile they diverge in height, text size, *and* shape. There's also a third variant of "the Order pill" in `BottomNavigation.tsx:176-193` with its own inline styles. This is the cost of not having a `Button` primitive actually used in these spots — the design system has one (`src/design-system/Button.tsx`) but the header/nav don't use it.
+
+**Extra:** on the order form page specifically, the header's "+ Order" links to `/orders/new` — the page you're already on. It arguably shouldn't render there at all.
+
+**Concept:** One shared button primitive (size + radius from a single spec; color variants only), consumed by Header, UserMenu, and BottomNavigation. Hide or swap the header Order CTA on `/orders/new`. **Quick Win for the size alignment; primitive consolidation → Overhaul**
+
+---
+
+## 6. "Feels like a web page, not a web app" — the professionalism gap
+
+**Observation:** The theme is right and stays. But sizing, spacing, margins, and general flow don't feel modern/professional-tier.
+
+**Diagnosis — concrete contributors found in code:**
+
+1. **No perceived performance layer** (item #3): full reloads with zero feedback is 80% of the "web page" feel. Modern-feeling apps are mostly *feedback*, not speed.
+2. **Competing max-widths:** sections use `maxWidth: '500px'` hard-coded (`CustomerHomeUI.tsx:178, 231, 285`, `QuickActions.tsx:31`) while the hero uses `var(--width-md)` (`FreshHero.tsx:31`). If those differ, content edges don't align vertically down the page — an instant "off" feeling nobody can name.
+3. **Spacing is per-component, not rhythmic:** every section brings its own padding (`var(--space-lg) var(--space-md)` here, `var(--space-xl)` there, `paddingBottom: '100px'` magic number in `CustomerHomeUI.tsx:230`). There's no vertical rhythm scale (e.g. all section gaps = `--space-xl`, all card innards = `--space-md`). Professional layouts are mostly consistent rhythm.
+4. **Shadow/elevation soup:** cards use `--shadow-md`, buttons `--shadow-md`, nav `--shadow-lg`, plus one-off `--shadow-coral`. Everything floats equally, so nothing has hierarchy. Pick 2 elevation levels for this surface.
+5. **Token violations undermining the system:** raw `rgba()` in the home mesh gradient (`CustomerHomeUI.tsx:100-104`), NavGrid border colors (`NavGrid.tsx:119-124`), FreshSheet item chips (`FreshSheet.tsx:67`) — all things CLAUDE.md itself bans. Also hard-coded `fontSize: '32px'/'14px'/'20px'` in NavGrid. This is the existing `docs/design-audit/phase-3-home.md` work.
+6. **Emoji as iconography** (🐟 📋 📍 💬 ⚙️ 🎙️ ⭐): renders differently per platform, can't take the theme's color, and reads homespun. A single-weight icon set (Lucide/Phosphor, stroke width tuned up for visibility) is probably the single biggest visual "professionalism" upgrade that doesn't touch the theme.
+7. **Inline styles everywhere** means no shared `:active`/`:focus`/`:hover` behavior and drift like #5 above. Not a user-visible issue per se, but it's why the inconsistencies keep appearing.
+
+**What's genuinely good and should not be lost:** the ocean gradient identity, big type in the hero, generous tap targets where they exist (52px star, 64px rows), `aria-*` and keyboard handling on the expanding rows, `prefers-reduced-motion` support, the county-grouped card list structure. The bones are right.
+
+---
+
+## Priority order
+
+### Quick wins (each small, independently shippable)
+1. **Dead controls:** wire or remove `#markets`, `#text`, `#directions-*` (items 2) and fix/hide signed-out mic (item 4). *A visible control must never no-op.*
+2. **Navigation feedback:** minimal top loading bar + `:active` pressed states app-wide (item 3, interim version).
+3. **Blue schedule → neutral**, add row pressed state + downward chevron (item 1).
+4. **Header button alignment** on one shared size spec; hide "+ Order" on the order page itself (item 5).
+
+### Overhaul pass (the "adversarial" design review — separate branch/worktree)
+Scope for a dedicated ticket:
+- **Enable RWSDK client navigation** + real transition indicators (foundation).
+- **Layout rhythm:** one content max-width token, one vertical spacing scale, 2-level elevation system.
+- **Button/pressable primitive** consumed everywhere (Header, UserMenu, BottomNav, NavGrid, row CTAs).
+- **Icon system** replacing emoji.
+- **Finish the token audit** (`docs/design-audit/` phases 0 & 3 cover most of the home-page violations).
+- **Constraint:** keep the theme (gradients, coral/ocean palette, big friendly type). Keep and extend the accessibility posture — 60+, outdoor sunlight, big targets, high contrast, explicit labels over clever minimalism.
+
+**Process note (per founder):** do the overhaul on an isolated branch/worktree so it can be evaluated against the current UI and discarded if it loses the plot. Current app works; the overhaul must earn its merge.

--- a/docs/design-audit/README.md
+++ b/docs/design-audit/README.md
@@ -5,6 +5,13 @@ Systematic review of all pages/components for design token compliance.
 **Created:** 2026-02-01
 **Goal:** Fix dark mode + establish consistent foundation
 
+## 2026-07-20 revival
+
+This folder is the reporting home for all design/UX review work.
+
+- **[2026-07-20 UX field review](./2026-07-20-ux-field-review.md)** — founder walkthrough findings traced to root causes; source of the quick-win fixes shipped on `claude/market-app-ux-review-03gn7v`.
+- **[Overhaul ticket](./overhaul-ticket.md)** — OPEN. Scope + method for the full "web app, not web page" pass (client navigation, layout rhythm, button primitive, icon system). Runs on an isolated worktree; absorbs phases 0 & 3 below.
+
 ## Status
 
 - [ ] Phase 0: Define missing tokens (`tokens.css`)

--- a/docs/design-audit/overhaul-ticket.md
+++ b/docs/design-audit/overhaul-ticket.md
@@ -1,0 +1,34 @@
+# Ticket: Design Overhaul Pass — "Web App, Not Web Page"
+
+**Status:** OPEN — not started
+**Created:** 2026-07-20
+**Origin:** [2026-07-20 UX field review](./2026-07-20-ux-field-review.md) (founder walkthrough of market.digitalglue.dev)
+**Process:** Run on an isolated worktree/branch. The overhaul must earn its merge against the current UI — if it loses the plot, discard it and keep what works.
+
+## Non-negotiable constraints
+
+- **Keep the theme.** Ocean gradients, coral/ocean palette, big friendly display type stay.
+- **Keep the accessibility posture.** Audience is 60+ customers at outdoor markets in sunlight: high contrast, big tap targets (≥48px), explicit labels over clever minimalism, obvious navigation over fancy patterns.
+- **Web app first.** Still a RedwoodSDK web app; React Native / Capacitor is a future option, not this ticket.
+
+## Scope
+
+1. **Client navigation foundation** — enable `initClientNavigation()` (currently `client.tsx` only calls `initClient()`, so every tap is a full document reload with no feedback in the standalone PWA). Test against auth/session/tenant middleware. Real transition indicators replace the interim progress bar shipped in the quick wins.
+2. **Layout rhythm** — one content max-width token (today: hard-coded `500px` in home sections vs `var(--width-md)` in the hero), one vertical spacing scale for section gaps, kill magic numbers (`paddingBottom: '100px'`).
+3. **Elevation system** — 2 levels max on the customer surface (today cards/buttons/nav all float at similar shadow weights, so nothing has hierarchy).
+4. **Pressable/Button primitive** — one shared spec consumed by Header, UserMenu, BottomNavigation, NavGrid, and row CTAs (today: three independently-styled "Order" pills exist).
+5. **Icon system** — replace emoji iconography (🐟📋📍💬⚙️🎙️) with a single-weight icon set (Lucide/Phosphor), stroke width tuned up for outdoor visibility.
+6. **Finish the token audit** — phases 0 and 3 of this folder cover most home-page violations (raw rgba mesh gradient, NavGrid border colors, hard-coded font sizes).
+
+## Method (when started)
+
+Adversarial multi-agent review → converge → implement on worktree:
+1. Fan-out review: independent passes over layout rhythm, interaction feedback, hierarchy/elevation, accessibility, and "modern app flow" — each producing findings with file:line evidence into this folder.
+2. Adversarial verify: second wave tries to refute each finding against the constraints above (especially "keep the theme" and 60+ accessibility).
+3. Synthesize into a phased implementation plan appended to this ticket.
+4. Implement phase-by-phase on the worktree branch; screenshot compare against production before merge.
+
+## Reporting
+
+- Findings and phase reports live in this folder (`docs/design-audit/`), one file per phase, linked from the README status table.
+- The README status list is the single source of truth for what's done.

--- a/src/app/pages/home/CustomerHomeUI.tsx
+++ b/src/app/pages/home/CustomerHomeUI.tsx
@@ -225,11 +225,12 @@ function AllMarketsSection({
   const isSingleNullGroup = countyGroups.size === 1 && countyGroups.has(null);
 
   return (
-    <div style={{
+    <div id="markets" style={{
       padding: 'var(--space-lg) var(--space-md)',
       paddingBottom: '100px',
       maxWidth: '500px',
-      margin: '0 auto'
+      margin: '0 auto',
+      scrollMarginTop: '80px' // Clear the sticky header when jumping to #markets
     }}>
       <div className="flex-between mb-md">
         <h2 className="heading-2xl m-0">

--- a/src/app/pages/home/components/BottomNavigation.tsx
+++ b/src/app/pages/home/components/BottomNavigation.tsx
@@ -123,6 +123,27 @@ export function BottomNavigation({ vendorSlug, vendorName, organizationId, user,
     }
   }, [chatConversationId, organizationId]);
 
+  // Open chat when navigating to #chat (e.g. hero "Contact" quick action)
+  useEffect(() => {
+    const openChatFromHash = () => {
+      if (window.location.hash !== '#chat') return;
+      setChatOpen(true);
+      if (organizationId) {
+        setUnreadCount(0);
+        const convId = getStoredConversationId(organizationId);
+        if (convId) {
+          markAsRead(convId, 'customer').catch(() => {});
+        }
+      }
+      // Clear the hash so tapping Contact again re-triggers hashchange
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    };
+
+    openChatFromHash();
+    window.addEventListener('hashchange', openChatFromHash);
+    return () => window.removeEventListener('hashchange', openChatFromHash);
+  }, [organizationId]);
+
   const loginHref = vendorSlug ? `/login?b=${vendorSlug}` : '/login';
 
   return (
@@ -192,29 +213,31 @@ export function BottomNavigation({ vendorSlug, vendorName, organizationId, user,
             Order
           </a>
 
-          {/* Mic */}
-          <button
-            onClick={openCommandBar}
-            aria-label="Voice command"
-            className="bottom-nav-mic"
-            style={{
-              padding: 'var(--space-sm)',
-              color: 'var(--color-action-primary)',
-              fontSize: 'var(--font-size-md)',
-              borderRadius: 'var(--radius-full)',
-              background: 'transparent',
-              border: '1.5px solid var(--color-border-light)',
-              cursor: 'pointer',
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '36px',
-              height: '36px',
-              transition: 'all 0.2s ease',
-            }}
-          >
-            🎙️
-          </button>
+          {/* Mic — only for signed-in users; CommandBar isn't mounted otherwise */}
+          {isLoggedIn && (
+            <button
+              onClick={openCommandBar}
+              aria-label="Voice command"
+              className="bottom-nav-mic"
+              style={{
+                padding: 'var(--space-sm)',
+                color: 'var(--color-action-primary)',
+                fontSize: 'var(--font-size-md)',
+                borderRadius: 'var(--radius-full)',
+                background: 'transparent',
+                border: '1.5px solid var(--color-border-light)',
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '36px',
+                height: '36px',
+                transition: 'all 0.2s ease',
+              }}
+            >
+              🎙️
+            </button>
+          )}
 
           <Menu.Root>
             <div style={{ position: 'relative', display: 'inline-flex' }}>

--- a/src/app/pages/home/components/CompactMarketRow.tsx
+++ b/src/app/pages/home/components/CompactMarketRow.tsx
@@ -87,7 +87,7 @@ export function CompactMarketRow({
           style={{
             fontSize: "var(--font-size-md)",
             fontWeight: "var(--font-weight-semibold)",
-            color: "var(--color-action-primary)",
+            color: "var(--color-text-primary)",
             whiteSpace: "nowrap",
             flexShrink: 0,
           }}
@@ -130,13 +130,13 @@ export function CompactMarketRow({
             fontSize: "var(--font-size-md)",
             color: "var(--color-text-tertiary)",
             transition: "transform 0.2s ease",
-            transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)",
+            transform: isExpanded ? "rotate(180deg)" : "rotate(0deg)",
             flexShrink: 0,
             lineHeight: 1,
           }}
           aria-hidden="true"
         >
-          {"\u203A"}
+          {"\u2304"}
         </span>
       </div>
 
@@ -168,47 +168,25 @@ export function CompactMarketRow({
             </div>
           )}
 
-          <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-            <a
-              href={`/orders/new?market=${market.id}${vendorSlug ? `&b=${vendorSlug}` : ""}`}
-              style={{
-                flex: 1,
-                padding: "var(--space-md)",
-                background: "var(--color-gradient-primary)",
-                color: "var(--color-text-inverse)",
-                border: "none",
-                borderRadius: "var(--radius-md)",
-                fontWeight: "var(--font-weight-bold)",
-                fontSize: "var(--font-size-md)",
-                textDecoration: "none",
-                textAlign: "center",
-                boxShadow: "var(--shadow-md)",
-              }}
-              className="btn btn--primary"
-            >
-              Order Fish
-            </a>
-
-            <a
-              href={`#directions-${market.id}`}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-xs)",
-                padding: "var(--space-md) var(--space-lg)",
-                background: "var(--color-surface-secondary)",
-                borderRadius: "var(--radius-md)",
-                textDecoration: "none",
-                fontSize: "var(--font-size-md)",
-                color: "var(--color-text-primary)",
-                fontWeight: "var(--font-weight-semibold)",
-                flexShrink: 0,
-              }}
-              aria-label={`Get directions to ${market.name}`}
-            >
-              <span aria-hidden="true">📍</span> Directions
-            </a>
-          </div>
+          <a
+            href={`/orders/new?market=${market.id}${vendorSlug ? `&b=${vendorSlug}` : ""}`}
+            style={{
+              display: "block",
+              padding: "var(--space-md)",
+              background: "var(--color-gradient-primary)",
+              color: "var(--color-text-inverse)",
+              border: "none",
+              borderRadius: "var(--radius-md)",
+              fontWeight: "var(--font-weight-bold)",
+              fontSize: "var(--font-size-md)",
+              textDecoration: "none",
+              textAlign: "center",
+              boxShadow: "var(--shadow-md)",
+            }}
+            className="btn btn--primary"
+          >
+            Order Fish
+          </a>
         </div>
       </div>
 
@@ -217,6 +195,9 @@ export function CompactMarketRow({
           outline: 2px solid var(--color-action-primary);
           outline-offset: -2px;
           border-radius: var(--radius-sm);
+        }
+        .compact-row-toggle:active {
+          background: var(--color-surface-secondary);
         }
         @media (prefers-reduced-motion: reduce) {
           .compact-row-expand {

--- a/src/app/pages/home/components/MarketCard.tsx
+++ b/src/app/pages/home/components/MarketCard.tsx
@@ -78,7 +78,7 @@ export function MarketCard({
         marginBottom: 'var(--space-lg)'
       }}>
         <span style={{
-          color: 'var(--color-action-primary)',
+          color: 'var(--color-text-primary)',
           fontWeight: 'var(--font-weight-semibold)',
           fontSize: 'var(--font-size-lg)'
         }}>
@@ -151,13 +151,6 @@ export function MarketCard({
             <span aria-hidden="true">⚙️</span>
           </a>
         )}
-        <a href={`#directions-${market.id}`} className="icon-button-md" style={{
-          background: 'var(--color-surface-secondary)',
-          textDecoration: 'none',
-          fontSize: 'var(--font-size-2xl)'
-        }} aria-label="Get directions">
-          <span aria-hidden="true">📍</span>
-        </a>
       </div>
     </div>
   );

--- a/src/app/pages/home/fetchVendorData.ts
+++ b/src/app/pages/home/fetchVendorData.ts
@@ -8,7 +8,7 @@ export function getQuickActions(vendorSlug?: string) {
     { icon: "🐟", title: "Order", href: orderHref },
     { icon: "📋", title: "My Orders", href: "/orders" },
     { icon: "📍", title: "Markets", href: "#markets" },
-    { icon: "💬", title: "Contact", href: "#text" }
+    { icon: "💬", title: "Contact", href: "#chat" }
   ];
 }
 

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -68,13 +68,14 @@
 .order-button {
   display: inline-flex;
   align-items: center;
-  padding: var(--space-xs) var(--space-md);
+  padding: var(--space-sm) var(--space-md);
   background: var(--color-gradient-secondary);
   color: white;
   border-radius: var(--radius-full);
   font-size: var(--text-sm);
   font-weight: 600;
   text-decoration: none;
+  white-space: nowrap;
   box-shadow: var(--shadow-coral);
   transition: all var(--duration-fast) var(--ease-out);
 }
@@ -136,12 +137,5 @@
 
   .unified-header__left {
     gap: var(--space-sm);
-  }
-
-  /* Reduce button padding on mobile */
-  .order-button {
-    padding: var(--space-xs) var(--space-sm);
-    font-size: var(--text-xs);
-    white-space: nowrap;
   }
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,6 +20,7 @@ interface HeaderProps {
   } | null;
   variant?: "customer" | "admin" | "auth";
   csrfToken?: string;
+  currentPath?: string;
 }
 
 export function Header({
@@ -28,6 +29,7 @@ export function Header({
   browsingOrganization,
   variant = "customer",
   csrfToken,
+  currentPath,
 }: HeaderProps) {
   // Auth variant: centered logo only
   if (variant === "auth") {
@@ -71,9 +73,11 @@ export function Header({
           <span className="unified-header__logo-text">{browsingOrganization?.name ?? currentOrganization?.name ?? "Fresh Catch"}</span>
         </a>
         <div className="unified-header__actions">
-          <a href={browsingOrganization?.slug ? `/orders/new?b=${browsingOrganization.slug}` : "/orders/new"} className="order-button">
-            + Order
-          </a>
+          {currentPath !== "/orders/new" && (
+            <a href={browsingOrganization?.slug ? `/orders/new?b=${browsingOrganization.slug}` : "/orders/new"} className="order-button">
+              + Order
+            </a>
+          )}
           <UserMenu user={user} currentOrganization={currentOrganization} browsingOrganization={browsingOrganization} csrfToken={csrfToken} />
         </div>
       </div>

--- a/src/components/NavigationProgress.tsx
+++ b/src/components/NavigationProgress.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import "./navigation-progress.css";
+
+/**
+ * NavigationProgress — interim feedback for full-page navigations.
+ *
+ * This app does full browser navigations (no client-side routing yet), and
+ * Workers + D1 cold starts mean a tap can sit for 1-3 seconds with zero
+ * visible response. This component watches for real same-origin link clicks
+ * and form submissions and immediately shows an indeterminate progress bar
+ * at the top of the viewport, so users know their tap registered.
+ *
+ * Remove once the client-navigation migration lands.
+ */
+
+// Safety net: if a navigation is aborted (stop button, offline, etc.) the
+// document sticks around — clear the bar so it doesn't hang forever.
+const RESET_AFTER_MS = 12000;
+
+function isPlainLeftClick(event: MouseEvent): boolean {
+  return (
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}
+
+/** True if following this anchor triggers a full page load in this tab. */
+function causesPageLoad(anchor: HTMLAnchorElement): boolean {
+  if (anchor.target && anchor.target !== "_self") return false;
+  if (anchor.hasAttribute("download")) return false;
+  if (!anchor.getAttribute("href")) return false;
+
+  let url: URL;
+  try {
+    url = new URL(anchor.href, window.location.href);
+  } catch {
+    return false;
+  }
+
+  // Covers external links and non-http schemes (mailto:, tel: have an
+  // opaque origin that never matches).
+  if (url.origin !== window.location.origin) return false;
+
+  // Hash-only jump within the current page: no page load happens.
+  if (
+    url.hash &&
+    url.pathname === window.location.pathname &&
+    url.search === window.location.search
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+/** True if submitting this form triggers a full page load in this tab. */
+function causesFormPageLoad(form: HTMLFormElement): boolean {
+  if (form.target && form.target !== "_self") return false;
+
+  // getAttribute avoids the classic footgun where an <input name="action">
+  // shadows form.action.
+  const action = form.getAttribute("action");
+  if (action) {
+    try {
+      if (new URL(action, window.location.href).origin !== window.location.origin) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function NavigationProgress() {
+  const [navigating, setNavigating] = useState(false);
+
+  useEffect(() => {
+    let resetTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const start = () => {
+      clearTimeout(resetTimer);
+      setNavigating(true);
+      resetTimer = setTimeout(() => setNavigating(false), RESET_AFTER_MS);
+    };
+
+    const stop = () => {
+      clearTimeout(resetTimer);
+      setNavigating(false);
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      if (!isPlainLeftClick(event)) return;
+      const anchor =
+        event.target instanceof Element
+          ? event.target.closest<HTMLAnchorElement>("a[href]")
+          : null;
+      if (!anchor || !causesPageLoad(anchor)) return;
+
+      // We listen in the capture phase, which runs before the target's own
+      // handlers — so defer the defaultPrevented check until the event has
+      // fully dispatched.
+      setTimeout(() => {
+        if (!event.defaultPrevented) start();
+      }, 0);
+    };
+
+    const handleSubmit = (event: SubmitEvent) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement)) return;
+      if (!causesFormPageLoad(form)) return;
+
+      setTimeout(() => {
+        if (!event.defaultPrevented) start();
+      }, 0);
+    };
+
+    // pageshow fires on bfcache restores (event.persisted) with the old DOM
+    // still live — reset unconditionally so back-navigation never shows a
+    // stuck bar. pagehide keeps the cached snapshot clean going the other way.
+    const handlePageShow = () => stop();
+    const handlePageHide = () => stop();
+
+    document.addEventListener("click", handleClick, true);
+    document.addEventListener("submit", handleSubmit, true);
+    window.addEventListener("pageshow", handlePageShow);
+    window.addEventListener("pagehide", handlePageHide);
+
+    return () => {
+      clearTimeout(resetTimer);
+      document.removeEventListener("click", handleClick, true);
+      document.removeEventListener("submit", handleSubmit, true);
+      window.removeEventListener("pageshow", handlePageShow);
+      window.removeEventListener("pagehide", handlePageHide);
+    };
+  }, []);
+
+  if (!navigating) return null;
+
+  return <div className="nav-progress" role="progressbar" aria-label="Loading page" />;
+}

--- a/src/components/UserMenu.css
+++ b/src/components/UserMenu.css
@@ -7,7 +7,7 @@
   padding: var(--space-sm) var(--space-md);
   background: var(--color-gradient-primary);
   color: var(--color-white);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-full);
   font-weight: 600;
   font-size: var(--text-sm);
   text-decoration: none;

--- a/src/components/navigation-progress.css
+++ b/src/components/navigation-progress.css
@@ -1,0 +1,47 @@
+/* NavigationProgress — indeterminate top-of-viewport progress bar shown
+   during full-page navigations. Sits above the sticky header (z-index 100)
+   and every overlay (highest elsewhere is 1200). */
+
+.nav-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  z-index: 1300;
+  pointer-events: none;
+  background: var(--color-gradient-primary);
+  transform-origin: left center;
+  /* Grow quickly to ~90%, then hold with a gentle pulse until the new
+     page replaces this one. */
+  animation:
+    nav-progress-grow 2s var(--ease-out) forwards,
+    nav-progress-pulse 1.4s ease-in-out 2s infinite;
+}
+
+@keyframes nav-progress-grow {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(0.9);
+  }
+}
+
+@keyframes nav-progress-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.6;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-progress {
+    /* Static full-width bar — still signals "loading", no animation. */
+    animation: none;
+    transform: none;
+  }
+}

--- a/src/design-system/interactions.css
+++ b/src/design-system/interactions.css
@@ -1,0 +1,27 @@
+/* Global pressed-state feedback (customer surface).
+   Full-page navigations take 1-3s on cold starts, so every tap needs an
+   instant physical response. Element-level selectors keep specificity
+   below existing component rules (.btn:active, .header-action:active),
+   so per-component pressed states still win where they're defined.
+
+   Note: transform is ignored on display:inline boxes, so plain inline
+   text links only get the brightness change — no layout shift. */
+
+button,
+a[href] {
+  transition:
+    transform 80ms var(--ease-out),
+    filter 80ms var(--ease-out);
+}
+
+button:active:not(:disabled),
+a[href]:active {
+  filter: brightness(0.95);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  button:active:not(:disabled),
+  a[href]:active {
+    transform: scale(0.97);
+  }
+}

--- a/src/layouts/CustomerLayout.tsx
+++ b/src/layouts/CustomerLayout.tsx
@@ -7,6 +7,9 @@ export function CustomerLayout({
   requestInfo,
 }: LayoutProps<RequestInfo>) {
   const ctx = requestInfo?.ctx;
+  const currentPath = requestInfo?.request
+    ? new URL(requestInfo.request.url).pathname
+    : undefined;
 
   return (
     <CustomerLayoutClient
@@ -14,6 +17,7 @@ export function CustomerLayout({
       currentOrganization={ctx?.currentOrganization ?? null}
       browsingOrganization={ctx?.browsingOrganization ?? null}
       csrfToken={ctx?.session?.csrfToken ?? ""}
+      currentPath={currentPath}
     >
       {children}
     </CustomerLayoutClient>

--- a/src/layouts/CustomerLayoutClient.tsx
+++ b/src/layouts/CustomerLayoutClient.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState, useCallback } from "react";
 import { ErrorBoundary } from "@/app/ErrorBoundary";
 import { Header } from "@/components/Header";
+import { NavigationProgress } from "@/components/NavigationProgress";
 import { CommandBar } from "@/components/CommandBar";
 import { CommandReview } from "@/components/CommandReview";
 import { QueryResultOverlay } from "@/components/QueryResultOverlay";
@@ -14,6 +15,7 @@ import { CustomerFooter } from "./CustomerFooter";
 import "./CustomerLayout.css";
 import "@/components/UserMenu.css";
 import "@/design-system/tokens.css";
+import "@/design-system/interactions.css";
 
 function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
   const m = hex.match(/^#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/);
@@ -26,6 +28,7 @@ export function CustomerLayoutClient({
   currentOrganization,
   browsingOrganization,
   csrfToken,
+  currentPath,
   children,
 }: {
   user: User | null;
@@ -43,6 +46,7 @@ export function CustomerLayoutClient({
     accentColor: string | null;
   } | null;
   csrfToken: string;
+  currentPath?: string;
   children: React.ReactNode;
 }) {
   const [commandBarOpen, setCommandBarOpen] = useState(false);
@@ -98,12 +102,14 @@ export function CustomerLayoutClient({
   return (
     <ErrorBoundary>
     <div className="customer-layout" data-surface="vendor" data-vendor={browsingOrganization?.slug ?? currentOrganization?.slug ?? undefined} style={accentStyle}>
+      <NavigationProgress />
       <Header
         variant="customer"
         user={user}
         currentOrganization={currentOrganization}
         browsingOrganization={browsingOrganization}
         csrfToken={csrfToken}
+        currentPath={currentPath}
       />
 
       <VoiceCommandProvider onOpen={() => setCommandBarOpen(true)}>


### PR DESCRIPTION
Fixes from two founder walkthroughs of the customer surface (2026-07-20 home/order flow, 2026-07-24 chat/order/profile/share). Diagnosis for both rounds is documented in `docs/design-audit/2026-07-20-ux-field-review.md`; the larger design overhaul is scoped separately in `docs/design-audit/overhaul-ticket.md` (not part of this PR).

## Round 1 — home & order flow

**Market rows (All Markets list + market cards)**
- Schedule text changed from action-blue to `--color-text-primary` so it no longer reads as a tappable link
- Expandable rows: chevron now points down and flips up when expanded, plus an `:active` pressed background so row-tappability is discoverable
- Removed dead Directions buttons — their `#directions-*` anchors had no target anywhere, so they silently did nothing

**Hero quick actions + mic**
- "Markets" now scrolls to the All Markets section; previously a dead `#markets` anchor
- "Contact" now opens the chat sheet via `#chat` hash handling; previously a dead `#text` anchor
- Mic button only renders when signed in — the CommandBar is never mounted for signed-out users, so the mic was a silent no-op

**Header**
- "+ Order" and "Sign In" buttons unified on one size spec (padding, font size at all breakpoints, pill radius); only their gradient colors differ
- "+ Order" is hidden on `/orders/new` itself (server-passed `currentPath` prop)

**Navigation feedback (interim until client navigation lands)**
- New `NavigationProgress` component: indeterminate top progress bar the moment a real same-origin navigation or form submit starts (full-page navigations in the standalone PWA previously gave zero loading indication). Handles bfcache restores, stuck-bar safety timeout
- New `interactions.css`: universal `:active` scale + brightness feedback on buttons/links, customer surface only, brightness-only under `prefers-reduced-motion`

## Round 2 — chat, order form, orders list, profile, share

- **Chat sheet**: close ✕ is now a 44px round tap target instead of a bare glyph
- **Order form**: contact fields get clear vertical separation so the Email label no longer hugs the Name input; Submit Order is the single dominant full-width action with an inline spinner while submitting; Cancel demoted to a low-emphasis text button below it that fades during submission; success redirect delay halved (2s → 1s)
- **Orders list / layout**: customer layout now fills the viewport (`min-height: 100dvh`) so the "Made by Digital Glue" footer sits flush at the bottom on short pages instead of floating in whitespace; footer tightened with a top border
- **Profile**: Save Changes is fullWidth like the app's other form buttons and disabled until the form is actually dirty (baseline resets after save)
- **Fab-bar menu**: removed the Settings item — `/settings` has no route and always 404'd
- **Share modal**: fixed the clipped Copy button (stacked full-width layout), added native share sheet when available, replaced brand-hex social slabs with calm outlined token-based buttons, framed the QR with a "point your camera" caption, removed the Download QR Code button, 44px close target

## Testing
- `pnpm run types` passes
- Design tokens only; aria attributes and keyboard handling preserved throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZUYPfAXxTK14ycSP1oPDJ