### PR TITLE
Admin: surface all admin routes on dashboard + per-org notification email

### DIFF
--- a/ADMIN_NAVIGATION_TODO.md
+++ b/ADMIN_NAVIGATION_TODO.md
@@ -217,18 +217,8 @@ function AccessDenied() {
 ```tsx
 export const adminRoutes = [
   route("/", AdminDashboard),        // NEW: /admin landing
-  route("/setup", SetupPage),        // /admin/setup
   route("/config", MarketConfigPage), // /admin/config
 ];
-```
-
-#### 6. Update Setup Page Redirect
-**File:** `src/app/pages/admin/Setup.tsx`
-
-After successful admin setup, redirect to `/admin` instead of `/admin/config`:
-```tsx
-// In handleFinish after successful registration
-window.location.href = "/admin"; // Changed from /admin/config
 ```
 
 ### Testing Checklist - Phase 1
@@ -237,7 +227,6 @@ window.location.href = "/admin"; // Changed from /admin/config
 - ✅ `/admin` shows access denied when logged in as non-admin
 - ✅ Navigation cards link to correct admin pages (Markets, View Site)
 - ✅ "View as Customer" navigates to `/` (customer home)
-- ✅ Setup page redirects to `/admin` after completion
 - ✅ Defensive CSS consistent across all auth/admin pages
 - ✅ Mobile-responsive layout works (cards stack properly)
 - ✅ MarketConfigPage has enhanced error handling (not logged in, not admin, no org)
@@ -428,7 +417,6 @@ interface AdminBadgeProps {
 
 **Modified Files:**
 - `src/app/pages/admin/routes.ts` - Add `/admin` route
-- `src/app/pages/admin/Setup.tsx` - Update redirect after setup
 - `src/app/pages/CustomerHomeUI.tsx` - Add admin header nav (Phase 2)
 
 **Design Files:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ git push -u origin bbb-new-feature
 
 ## Project Overview
 
-This is a RedwoodSDK (RWSDK) project - a TypeScript framework for building server-driven web applications on Cloudflare Workers with React Server Components, WebAuthn authentication, and Prisma ORM with D1 database.
+This is a RedwoodSDK (RWSDK) project - a TypeScript framework for building server-driven web applications on Cloudflare Workers with React Server Components, email-OTP authentication, and Prisma ORM with D1 database.
 
 **Current RWSDK Version:** 1.0.0-beta.42 (upgraded from beta.9 on 2025-12-24)
 
@@ -104,12 +104,12 @@ pnpm run clean          # Clean Vite cache
 
 ### Database
 - Uses Prisma with D1 adapter for SQLite on Cloudflare
-- Schema includes `User` and `Credential` models for WebAuthn authentication
+- Schema includes `User` model (email-OTP login) and a legacy `Credential` model from a prior WebAuthn implementation, no longer wired up
 - Generated Prisma client outputs to `generated/prisma/`
 - Migrations stored in `migrations/` directory
 
 ### Authentication
-- WebAuthn (passkey) authentication via `@simplewebauthn` packages
+- Email-OTP (login code) authentication — see `src/auth/login-codes.ts`
 - User routes in `src/app/pages/user/` handle login/registration
 - Sessions persist via Durable Objects with automatic cleanup on auth errors
 
@@ -344,6 +344,6 @@ export { BottomNavigationV2 as BottomNavigation } from './BottomNavigation.v2';
 
 - TypeScript paths configured: `@/*` maps to `src/*`, `@generated/*` maps to `generated/*`
 - Uses pnpm as package manager
-- Environment variables needed: `DATABASE_URL`, `WEBAUTHN_APP_NAME`
+- Environment variables needed: `DATABASE_URL`, `RESEND_API_KEY` (for login-code + notification emails)
 - Cloudflare D1 database binding configured as `DB`
 - Update `__change_me__` placeholders in `wrangler.jsonc` for deployment

--- a/migrations/0032_add_notification_email.sql
+++ b/migrations/0032_add_notification_email.sql
@@ -1,0 +1,4 @@
+-- Migration: Add notificationEmail to Organization for per-org order notifications
+-- Nullable, existing orgs unaffected
+
+ALTER TABLE "Organization" ADD COLUMN "notificationEmail" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,9 @@ model Organization {
   // Branding
   accentColor String? // Hex color for vendor storefront theming (e.g., "#FF6B6B")
 
+  // Notifications
+  notificationEmail String? // recipient for new-order + ops notifications
+
   // API key for external MCP access (only hash stored, never raw key)
   apiKeyHash   String?
   apiKeyPrefix String?

--- a/src/app/pages/admin/AdminDashboardUI.tsx
+++ b/src/app/pages/admin/AdminDashboardUI.tsx
@@ -89,6 +89,105 @@ export function AdminDashboardUI({ ctx }: AdminDashboardUIProps) {
           </div>
         </a>
 
+        {/* Orders Card */}
+        <a href="/admin/orders" className="admin-nav-card">
+          <div className="admin-nav-card__icon">📦</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Orders</h3>
+            <p className="admin-nav-card__description">
+              View and manage customer orders
+            </p>
+          </div>
+        </a>
+
+        {/* Team Card */}
+        <a href="/admin/team" className="admin-nav-card">
+          <div className="admin-nav-card__icon">👥</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Team</h3>
+            <p className="admin-nav-card__description">
+              Manage team members and roles
+            </p>
+          </div>
+        </a>
+
+        {/* Messages Card */}
+        <a href="/admin/messages" className="admin-nav-card">
+          <div className="admin-nav-card__icon">💬</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Messages</h3>
+            <p className="admin-nav-card__description">
+              Chat with customers
+            </p>
+          </div>
+        </a>
+
+        {/* Payments Card */}
+        <a href="/admin/settings/stripe" className="admin-nav-card">
+          <div className="admin-nav-card__icon">💳</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Payments</h3>
+            <p className="admin-nav-card__description">
+              Stripe account and fee settings
+            </p>
+          </div>
+        </a>
+
+        {/* Branding Card */}
+        <a href="/admin/settings/branding" className="admin-nav-card">
+          <div className="admin-nav-card__icon">🎨</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Branding</h3>
+            <p className="admin-nav-card__description">
+              Customize your storefront accent color
+            </p>
+          </div>
+        </a>
+
+        {/* API Access Card */}
+        <a href="/admin/settings/api" className="admin-nav-card">
+          <div className="admin-nav-card__icon">🔑</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">API Access</h3>
+            <p className="admin-nav-card__description">
+              Manage external MCP API keys
+            </p>
+          </div>
+        </a>
+
+        {/* Notifications Card */}
+        <a href="/admin/settings/notifications" className="admin-nav-card">
+          <div className="admin-nav-card__icon">🔔</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Notifications</h3>
+            <p className="admin-nav-card__description">
+              Set where order notifications are sent
+            </p>
+          </div>
+        </a>
+
+        {/* Gaps Card */}
+        <a href="/admin/gaps" className="admin-nav-card">
+          <div className="admin-nav-card__icon">🕳️</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Gaps</h3>
+            <p className="admin-nav-card__description">
+              Coverage gaps and unmet demand
+            </p>
+          </div>
+        </a>
+
+        {/* Insights Card */}
+        <a href="/admin/insights" className="admin-nav-card">
+          <div className="admin-nav-card__icon">📊</div>
+          <div className="admin-nav-card__content">
+            <h3 className="admin-nav-card__title">Insights</h3>
+            <p className="admin-nav-card__description">
+              Demand signals and customer analytics
+            </p>
+          </div>
+        </a>
+
         {/* Share Business Card */}
         <button
           onClick={() => setShareModalOpen(true)}

--- a/src/app/pages/admin/NotificationSettingsPage.tsx
+++ b/src/app/pages/admin/NotificationSettingsPage.tsx
@@ -1,0 +1,46 @@
+import { RequestInfo } from "rwsdk/worker";
+import { db } from "@/db";
+import { hasAdminAccess } from "@/utils/permissions";
+import { NotificationSettingsUI } from "./NotificationSettingsUI";
+import { NotAuthenticated, AccessDenied, NoOrganization } from "./components";
+
+export async function NotificationSettingsPage(requestInfo: RequestInfo) {
+  const { ctx } = requestInfo;
+
+  if (!ctx.user) return <NotAuthenticated />;
+  if (!hasAdminAccess(ctx)) return <AccessDenied />;
+  if (!ctx.currentOrganization) return <NoOrganization />;
+
+  const org = await db.organization.findUnique({
+    where: { id: ctx.currentOrganization.id },
+    select: {
+      id: true,
+      name: true,
+      notificationEmail: true,
+    },
+  });
+
+  if (!org) {
+    return (
+      <div className="error-page">
+        <div className="error-card">
+          <div className="error-icon">!</div>
+          <h1 className="error-title">Organization Not Found</h1>
+          <p className="error-description">Could not load organization data.</p>
+          <div className="error-actions">
+            <a href="/admin" className="error-secondary-link">Back to Admin</a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <NotificationSettingsUI
+      orgId={org.id}
+      orgName={org.name}
+      notificationEmail={org.notificationEmail}
+      csrfToken={ctx.session!.csrfToken}
+    />
+  );
+}

--- a/src/app/pages/admin/NotificationSettingsUI.tsx
+++ b/src/app/pages/admin/NotificationSettingsUI.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Button } from "@/design-system";
+import { updateNotificationEmail } from "./notification-functions";
+import "./admin.css";
+
+export function NotificationSettingsUI({
+  orgId,
+  orgName,
+  notificationEmail,
+  csrfToken,
+}: {
+  orgId: string;
+  orgName: string;
+  notificationEmail: string | null;
+  csrfToken: string;
+}) {
+  const [email, setEmail] = useState(notificationEmail ?? "");
+  const [isPending, startTransition] = useTransition();
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = () => {
+    setMessage(null);
+    setError(null);
+
+    startTransition(async () => {
+      const result = await updateNotificationEmail(
+        csrfToken,
+        orgId,
+        email.trim() || null
+      );
+      if (result.success) {
+        setMessage("Notification email saved");
+      } else {
+        setError(result.error);
+      }
+    });
+  };
+
+  return (
+    <div style={{ maxWidth: "var(--width-sm)", margin: "0 auto", padding: "var(--space-lg)" }}>
+      <h1 style={{ fontSize: "var(--font-size-2xl)", fontWeight: "var(--font-weight-bold)", marginBottom: "var(--space-sm)", color: "var(--color-text-primary)" }}>
+        Notifications
+      </h1>
+      <p style={{ color: "var(--color-text-secondary)", fontSize: "var(--font-size-sm)", marginBottom: "var(--space-lg)" }}>
+        Choose where new-order notifications for {orgName} are sent
+      </p>
+
+      <div style={{
+        background: "var(--color-surface-primary)",
+        borderRadius: "var(--radius-sm)",
+        padding: "var(--space-md)",
+        border: "1px solid var(--color-border-light)",
+      }}>
+        <label style={{
+          display: "block",
+          marginBottom: "var(--space-xs)",
+          fontSize: "var(--font-size-sm)",
+          color: "var(--color-text-primary)",
+        }}>
+          Notification email
+        </label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="orders@yourbusiness.com"
+          style={{
+            width: "100%",
+            padding: "var(--space-sm)",
+            borderRadius: "var(--radius-sm)",
+            border: "1px solid var(--color-border-input)",
+            fontSize: "var(--font-size-md)",
+            color: "var(--color-text-primary)",
+            marginBottom: "var(--space-md)",
+            boxSizing: "border-box",
+          }}
+        />
+        <p style={{ fontSize: "var(--font-size-xs)", color: "var(--color-text-secondary)", marginBottom: "var(--space-md)" }}>
+          Leave blank to fall back to the account owner's email.
+        </p>
+
+        <div style={{ width: "100%" }}>
+          <Button
+            variant="primary"
+            onClick={handleSave}
+            disabled={isPending}
+          >
+            {isPending ? "Saving..." : "Save"}
+          </Button>
+        </div>
+
+        {message && (
+          <div style={{
+            marginTop: "var(--space-sm)",
+            padding: "var(--space-xs)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--color-status-success-bg)",
+            color: "var(--color-status-success-border)",
+            fontSize: "var(--font-size-sm)",
+            textAlign: "center",
+          }}>
+            {message}
+          </div>
+        )}
+        {error && (
+          <div style={{
+            marginTop: "var(--space-sm)",
+            padding: "var(--space-xs)",
+            borderRadius: "var(--radius-sm)",
+            background: "var(--color-status-error-bg)",
+            color: "var(--color-status-error)",
+            fontSize: "var(--font-size-sm)",
+            textAlign: "center",
+          }}>
+            {error}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/pages/admin/notification-functions.ts
+++ b/src/app/pages/admin/notification-functions.ts
@@ -1,0 +1,40 @@
+"use server";
+
+import { requestInfo } from "rwsdk/worker";
+import { db } from "@/db";
+import { hasAdminAccess } from "@/utils/permissions";
+import { requireCsrf } from "@/session/csrf";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function updateNotificationEmail(
+  csrfToken: string,
+  orgId: string,
+  notificationEmail: string | null
+) {
+  requireCsrf(csrfToken);
+
+  const { ctx } = requestInfo;
+
+  if (!hasAdminAccess(ctx) || orgId !== ctx.currentOrganization?.id) {
+    return { success: false as const, error: "Admin access required" };
+  }
+
+  const trimmed = notificationEmail?.trim() || null;
+
+  if (trimmed !== null && (trimmed.length > 254 || !EMAIL_RE.test(trimmed))) {
+    return { success: false as const, error: "Invalid email address" };
+  }
+
+  try {
+    await db.organization.update({
+      where: { id: orgId },
+      data: { notificationEmail: trimmed },
+    });
+
+    return { success: true as const };
+  } catch (error) {
+    console.error("Failed to update notification email:", error);
+    return { success: false as const, error: "Failed to update notification email" };
+  }
+}

--- a/src/app/pages/admin/routes.ts
+++ b/src/app/pages/admin/routes.ts
@@ -9,6 +9,7 @@ import { CatchPage } from "./catch/CatchPage";
 import { MessagesPage } from "./messages/MessagesPage";
 import { BrandingSettingsPage } from "./BrandingSettingsPage";
 import { ApiSettingsPage } from "./ApiSettingsPage";
+import { NotificationSettingsPage } from "./NotificationSettingsPage";
 import { GapsPage } from "./gaps/GapsPage";
 import { InsightsPage } from "./insights/InsightsPage";
 
@@ -20,6 +21,7 @@ export const adminRoutes = [
   route("/settings/stripe", StripeSettingsPage), // /admin/settings/stripe
   route("/settings/branding", BrandingSettingsPage), // /admin/settings/branding
   route("/settings/api", ApiSettingsPage),             // /admin/settings/api
+  route("/settings/notifications", NotificationSettingsPage), // /admin/settings/notifications
   route("/team", TeamPage),           // /admin/team
   route("/catch", CatchPage),         // /admin/catch
   route("/messages", MessagesPage),    // /admin/messages

--- a/src/app/pages/orders/functions.ts
+++ b/src/app/pages/orders/functions.ts
@@ -80,6 +80,7 @@ export async function createOrder(csrfToken: string, data: CreateOrderData, vend
       notificationEmail: true,
       memberships: {
         where: { role: "owner" },
+        orderBy: { createdAt: "asc" }, // deterministic: oldest owner if multiple
         take: 1,
         include: { user: { select: { email: true } } },
       },

--- a/src/app/pages/orders/functions.ts
+++ b/src/app/pages/orders/functions.ts
@@ -72,7 +72,18 @@ export async function createOrder(csrfToken: string, data: CreateOrderData, vend
   // Look up vendor org explicitly by ID passed from client
   const vendorOrg = await db.organization.findUnique({
     where: { id: vendorOrgId },
-    select: { id: true, name: true, slug: true, type: true },
+    select: {
+      id: true,
+      name: true,
+      slug: true,
+      type: true,
+      notificationEmail: true,
+      memberships: {
+        where: { role: "owner" },
+        take: 1,
+        include: { user: { select: { email: true } } },
+      },
+    },
   });
   if (!vendorOrg || vendorOrg.type !== "business") {
     return { success: false, error: "Invalid vendor" };
@@ -163,10 +174,14 @@ export async function createOrder(csrfToken: string, data: CreateOrderData, vend
     }
 
     // Send notification email to admin
-    if (env.ADMIN_EMAIL) {
+    const notificationRecipient =
+      vendorOrg.notificationEmail ||
+      vendorOrg.memberships[0]?.user.email ||
+      env.ADMIN_EMAIL;
+    if (notificationRecipient) {
       try {
         await sendAdminNewOrderEmail({
-          to: env.ADMIN_EMAIL,
+          to: notificationRecipient,
           orderNumber: order.orderNumber,
           customerName: order.contactName,
           customerEmail: order.contactEmail || undefined,


### PR DESCRIPTION
## Summary
Adds a per-organization notification email so new-order emails go to each vendor's own inbox instead of a single global `ADMIN_EMAIL`, and surfaces every existing admin route as a card on the admin dashboard so nothing is reachable by URL only. Also refreshes stale docs (WebAuthn → email-OTP, removed deleted `Setup.tsx` references).

## What changed
- **Schema/data**: new nullable `Organization.notificationEmail` (migration `0032`, sequential, existing orgs unaffected).
- **Settings page**: `/admin/settings/notifications` — mirrors the branding settings page/UI/functions pattern (CSRF + admin/org-ownership guard + email validation).
- **Orders**: `createOrder` resolves the notification recipient as `notificationEmail → oldest owner membership email → ADMIN_EMAIL`.
- **Dashboard nav**: added cards for Orders, Team, Messages, Payments, Branding, API Access, Notifications, Gaps, Insights.
- **Docs**: `CLAUDE.md` auth section corrected to email-OTP (Credential model noted as legacy); `ADMIN_NAVIGATION_TODO.md` stripped of deleted `Setup.tsx` steps.

## How it was verified
- `pnpm run types` → clean.
- `pnpm run test` → 30/30 passing, 8 files.
- Migration numbering confirmed sequential (0031 → 0032), no collision.
- **Not tested**: live email send (no `RESEND_API_KEY` in dev) — recipient resolution confirmed by code read only.

## Review notes (reviewer: independent pass, did not author)
- Confirmed `notification-functions.ts` is a faithful mirror of `branding-functions.ts` (same CSRF/authz/validation shape).
- Verified `role: "owner"` matches the membership convention used across the codebase.
- Verified all 9 nav-card hrefs map to routes registered in `admin/routes.ts`.
- **Fix added** (`review:` commit 4257967): owner-membership fallback lookup had `take: 1` with no `orderBy`, making the recipient non-deterministic for multi-owner orgs. Added `orderBy: { createdAt: "asc" }` so it deterministically picks the oldest owner.

## Risks / rollback
- Low risk: additive nullable column + new page + additive nav cards.
- **Known, out of scope**: the Insights card is now surfaced but the insights page still has an unfixed authz hole (P0-6) — tracked as a separate bead; this PR does not widen it (the route already existed).
- Rollback: revert the branch; migration only adds a nullable column (safe to leave or drop).