### PR TITLE
chore: make pre-pr-review-gate hook worktree-aware

### DIFF
--- a/.claude/hooks/pre-pr-review-gate.sh
+++ b/.claude/hooks/pre-pr-review-gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # PreToolUse gate: require a medium-effort branch review before `gh pr create`.
-# Pass condition: .git/.pr-review-ok contains the current HEAD sha (written after a review).
+# Pass condition: the .pr-review-ok marker (resolved via `git rev-parse --git-path`, so it
+# lands in the per-worktree gitdir) contains the current HEAD sha (written after a review).
 # Marker is consumed on success so each new PR needs a fresh review.
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
@@ -9,7 +10,9 @@ case "$cmd" in
   *) exit 0 ;;
 esac
 
-marker=".git/.pr-review-ok"
+# Resolve marker via git so it works in worktrees (where .git is a file, not a dir)
+marker=$(git rev-parse --git-path .pr-review-ok 2>/dev/null)
+[ -n "$marker" ] || marker=".git/.pr-review-ok"
 head=$(git rev-parse HEAD 2>/dev/null)
 if [ -n "$head" ] && [ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$head" ]; then
   rm -f "$marker"
@@ -17,6 +20,6 @@ if [ -n "$head" ] && [ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$he
 fi
 
 cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Pre-PR review gate: run a medium-effort review of this branch first (invoke the code-review skill at medium effort, or review git diff main...HEAD yourself: verify findings in actual code, fix confirmed critical/major issues, run pnpm test). When the review is done and the branch is final, mark it reviewed with: git rev-parse HEAD > .git/.pr-review-ok  — then retry gh pr create. Note: any new commit invalidates the marker."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Pre-PR review gate: run a medium-effort review of this branch first (invoke the code-review skill at medium effort, or review git diff main...HEAD yourself: verify findings in actual code, fix confirmed critical/major issues, run pnpm test). When the review is done and the branch is final, mark it reviewed with: git rev-parse HEAD > \"$(git rev-parse --git-path .pr-review-ok)\"  — then retry gh pr create. Note: any new commit invalidates the marker."}}
 EOF
 exit 0


### PR DESCRIPTION
## Summary
The pre-PR review gate hook resolved its review marker via a hard-coded `.git/.pr-review-ok` path. In git worktrees (which Agor branches use) `.git` is a gitdir-pointer *file*, not a directory, so that path can never exist — the gate was unsatisfiable and hard-blocked every worktree review session from opening a PR. This resolves the marker via git so it lands in the correct per-worktree gitdir. Same review requirement, now works everywhere.

## What changed
- `.claude/hooks/pre-pr-review-gate.sh`: marker path now `git rev-parse --git-path .pr-review-ok`, with fallback to the literal `.git/.pr-review-ok` for plain clones. Comment + deny-message instruction updated to the worktree-correct command.

## How it was verified
- `bash -n` syntax check: clean.
- Behavioral simulation (in a worktree): no marker → deny; marker=HEAD → allow + marker consumed; non-PR command → silent pass.
- Marker now resolves to `.../worktrees/<branch>/.pr-review-ok` instead of an impossible path.

## Risks / rollback
- Very low: single hook script, logic otherwise unchanged; fallback preserves plain-clone behavior.
- Rollback: revert this one-file commit.