### PR TITLE
Fix voice inventory Save: stop items array collapsing to a string (P0-11)

### DIFF
--- a/src/ai/workers-ai-client.ts
+++ b/src/ai/workers-ai-client.ts
@@ -1,10 +1,10 @@
 /**
  * Workers AI client for text generation with tool calling.
- * Replaces Anthropic SDK — uses Kimi K2.5 for tool use, Llama 3.3 for simple queries.
+ * Replaces Anthropic SDK — uses Kimi K2.6 for tool use, Llama 3.3 for simple queries.
  */
 import { env } from "cloudflare:workers";
 
-const MODEL_KIMI = "@cf/moonshotai/kimi-k2.5";
+const MODEL_KIMI = "@cf/moonshotai/kimi-k2.6";
 const MODEL_LLAMA = "@cf/meta/llama-3.3-70b-instruct-fp8-fast";
 const DEFAULT_TEMPERATURE = 0.7;
 

--- a/src/api/voice-command.ts
+++ b/src/api/voice-command.ts
@@ -212,7 +212,7 @@ export async function handleVoiceCommand(
   try {
     const ai = (env as unknown as { AI: { run: (model: string, input: Record<string, unknown>) => Promise<Record<string, unknown>> } }).AI;
 
-    aiResult = (await ai.run("@cf/moonshotai/kimi-k2.5", {
+    aiResult = (await ai.run("@cf/moonshotai/kimi-k2.6", {
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: rawTranscript },

--- a/src/api/voice-tools.ts
+++ b/src/api/voice-tools.ts
@@ -162,6 +162,8 @@ type SchemaField = {
   type: string;
   optional?: boolean;
   description?: string;
+  /** Explicit JSON Schema override for tool-calling models (bypasses toJsonSchemaType). */
+  jsonSchema?: Record<string, unknown>;
 };
 
 type VoiceTool = {
@@ -181,6 +183,18 @@ export const voiceTools: Record<string, VoiceTool> = {
       items: {
         type: "array of { name: string, quantity: number, unit: string }",
         description: "Items to order",
+        jsonSchema: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              quantity: { type: "number" },
+              unit: { type: "string" },
+            },
+            required: ["name", "quantity", "unit"],
+          },
+        },
       },
       pickupMarketId: {
         type: "string",
@@ -234,6 +248,17 @@ export const voiceTools: Record<string, VoiceTool> = {
       items: {
         type: "array of { name: string, note: string }",
         description: "Fish items with colorful descriptions",
+        jsonSchema: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              note: { type: "string" },
+            },
+            required: ["name", "note"],
+          },
+        },
       },
       summary: { type: "string", description: "One-sentence summary" },
     },
@@ -567,7 +592,9 @@ export function mcpFormat(role: string = "owner"): McpTool[] {
     const required: string[] = [];
 
     for (const [fieldName, field] of Object.entries(tool.schema)) {
-      const prop: Record<string, unknown> = { ...toJsonSchemaType(field.type) };
+      const prop: Record<string, unknown> = {
+        ...(field.jsonSchema ?? toJsonSchemaType(field.type)),
+      };
       if (field.description) prop.description = field.description;
       properties[fieldName] = prop;
       if (!field.optional) required.push(fieldName);

--- a/src/components/CommandReview.tsx
+++ b/src/components/CommandReview.tsx
@@ -99,7 +99,7 @@ function isDateInPast(dateStr: string): boolean {
   return dateStr < getTodayStr();
 }
 
-function parseCatchPreview(raw: unknown): CatchItem[] {
+function parseItemsList(raw: unknown): unknown[] {
   if (!raw) return [];
   try {
     const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
@@ -814,9 +814,7 @@ export function CommandReview({
   // Initialize form data from voice result
   const [catchData, setCatchData] = useState<CatchFormData>(() => ({
     headline: (result.data.headline as string) || "",
-    items: Array.isArray(result.data.items)
-      ? (result.data.items as CatchItem[])
-      : [],
+    items: parseItemsList(result.data.items) as CatchItem[],
     summary: (result.data.summary as string) || "",
   }));
 
@@ -826,7 +824,7 @@ export function CommandReview({
     active: true,
     locationDetails: (result.data.locationDetails as string) || "",
     customerInfo: (result.data.customerInfo as string) || "",
-    catchPreview: parseCatchPreview(result.data.catchPreview),
+    catchPreview: parseItemsList(result.data.catchPreview) as CatchItem[],
   }));
 
   const [popupData, setPopupData] = useState<PopupFormData>(() => ({
@@ -835,7 +833,7 @@ export function CommandReview({
     active: true,
     locationDetails: (result.data.locationDetails as string) || "",
     customerInfo: (result.data.customerInfo as string) || "",
-    catchPreview: parseCatchPreview(result.data.catchPreview),
+    catchPreview: parseItemsList(result.data.catchPreview) as CatchItem[],
     expiresAt: (result.data.expiresAt as string) || "",
     notes: (result.data.notes as string) || "",
   }));
@@ -869,13 +867,11 @@ export function CommandReview({
   const [marketCatchData, setMarketCatchData] = useState<MarketCatchFormData>(() => ({
     marketId: (result.data.marketId as string) || "",
     marketName: (result.data.marketName as string) || (result.data.name as string) || "",
-    items: parseCatchPreview(result.data.catchPreview),
+    items: parseItemsList(result.data.catchPreview) as CatchItem[],
   }));
 
   const [orderData, setOrderData] = useState<OrderFormData>(() => ({
-    items: Array.isArray(result.data.items)
-      ? (result.data.items as OrderItem[])
-      : [],
+    items: parseItemsList(result.data.items) as OrderItem[],
     pickupMarketId: (result.data.pickupMarketId as string) || "",
     pickupDate: (result.data.pickupDate as string) || "",
     customerNote: (result.data.customerNote as string) || "",

--- a/src/layouts/AdminLayoutClient.tsx
+++ b/src/layouts/AdminLayoutClient.tsx
@@ -183,13 +183,14 @@ function AdminNav({ isOwner, pendingOrderCount }: { isOwner: boolean; pendingOrd
   useEffect(() => { setPath(window.location.pathname); }, []);
 
   const isActive = (href: string) => {
-    if (href === '/admin') return path === '/admin' || path === '/admin/config' || path === '/admin/catch';
+    if (href === '/admin') return path === '/admin' || path === '/admin/config';
     if (href.startsWith('/admin/settings')) return path.startsWith('/admin/settings');
     return path.startsWith(href);
   };
 
   const tabs = [
     { href: '/admin', label: 'Markets' },
+    { href: '/admin/catch', label: 'Catch' },
     { href: '/admin/orders', label: 'Orders', badge: pendingOrderCount },
     ...(isOwner ? [{ href: '/admin/team', label: 'Team' }] : []),
     { href: '/admin/messages', label: 'Messages' },


### PR DESCRIPTION
## Summary
Voice inventory Save was broken (P0-11): the `update_catch.items` array field collapsed to a JSON-Schema `string` in the tool definition, so the model emitted a string, the review form dropped it, and Save stayed disabled with an empty item list. This sets an explicit array-of-object JSON Schema on the affected tool fields so the model returns a real array. Same root cause is fixed for `create_order.items`, plus two small bundled items: surfacing `/admin/catch` in the admin nav and bumping the Kimi model to k2.6.

Closes P0-11.

## What changed
- **`src/api/voice-tools.ts`** — added an optional `SchemaField.jsonSchema` override; `mcpFormat` now uses it when present. Set explicit `{type:"array", items:{type:"object", ...}}` schemas on `update_catch.items` (`{name, note}`) and `create_order.items` (`{name, quantity, unit}`) instead of falling back to `toJsonSchemaType`'s string collapse. Flows through `toWorkersAiTools` → the live `ai.run` call, i.e. the actual runtime path.
- **`src/components/CommandReview.tsx`** — generalized `parseCatchPreview` → `parseItemsList(unknown[])` and used it to initialize `catchData.items` / `orderData.items`, so a string-encoded array still populates the form as a safety net (behavior-preserving for the existing `catchPreview` callers).
- **`src/layouts/AdminLayoutClient.tsx`** — added a **Catch** tab (2nd position) to admin nav and removed `/admin/catch` from the `isActive('/admin')` clause so it lights the new tab. Route already exists (`admin/routes.ts:24`).
- **`src/ai/workers-ai-client.ts`, `src/api/voice-command.ts`** — bumped Kimi `k2.5` → `k2.6`.

## How it was verified
- `pnpm run types` — clean.
- `pnpm test` — 30/30 passed (8 files).
- Confirmed `mcpFormat` now emits array-of-object schema for the two fields (not `{type:"string"}`), and that `toWorkersAiTools` → `ai.run` uses that output.
- Confirmed `/admin/catch` route exists and `isActive` lights only the Catch tab.
- Confirmed no stale `parseCatchPreview` references remain in `CommandReview.tsx`.
- (From author, replicated context) live model test against `@cf/moonshotai/kimi-k2.6` returned `items` as a real JSON array of objects.
- **NOT tested:** full browser UI pass (mic FAB → Save → customer home) — no auth session in this sandbox. Recommend one manual pass before merge.

## Review notes
Independent review (I did not write this code). Verified the fix reaches the runtime path (`toWorkersAiTools` delegates to `mcpFormat`), the client change is behavior-preserving, and the nav route is not dead. Scope is tight — `catchPreview` fields remain JSON strings by design and are handled by the client parser. No changes needed; no review commits added.

## Risks / rollback
- Low risk. If the k2.6 model regresses on tool selection, revert the two model-string bumps independently. If the schema change causes issues, the client `parseItemsList` safety net still decodes string-encoded arrays.
- Rollback: revert commit `a22c097`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
