### PR TITLE
Admin mutations update the UI instantly (Market Settings + Orders)

### DIFF
--- a/.claude/hooks/pre-pr-review-gate.sh
+++ b/.claude/hooks/pre-pr-review-gate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # PreToolUse gate: require a medium-effort branch review before `gh pr create`.
-# Pass condition: .git/.pr-review-ok contains the current HEAD sha (written after a review).
+# Pass condition: the .pr-review-ok marker (resolved via `git rev-parse --git-path`, so it
+# lands in the per-worktree gitdir) contains the current HEAD sha (written after a review).
 # Marker is consumed on success so each new PR needs a fresh review.
 input=$(cat)
 cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty')
@@ -9,7 +10,9 @@ case "$cmd" in
   *) exit 0 ;;
 esac
 
-marker=".git/.pr-review-ok"
+# Resolve marker via git so it works in worktrees (where .git is a file, not a dir)
+marker=$(git rev-parse --git-path .pr-review-ok 2>/dev/null)
+[ -n "$marker" ] || marker=".git/.pr-review-ok"
 head=$(git rev-parse HEAD 2>/dev/null)
 if [ -n "$head" ] && [ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$head" ]; then
   rm -f "$marker"
@@ -17,6 +20,6 @@ if [ -n "$head" ] && [ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$he
 fi
 
 cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Pre-PR review gate: run a medium-effort review of this branch first (invoke the code-review skill at medium effort, or review git diff main...HEAD yourself: verify findings in actual code, fix confirmed critical/major issues, run pnpm test). When the review is done and the branch is final, mark it reviewed with: git rev-parse HEAD > .git/.pr-review-ok  — then retry gh pr create. Note: any new commit invalidates the marker."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Pre-PR review gate: run a medium-effort review of this branch first (invoke the code-review skill at medium effort, or review git diff main...HEAD yourself: verify findings in actual code, fix confirmed critical/major issues, run pnpm test). When the review is done and the branch is final, mark it reviewed with: git rev-parse HEAD > \"$(git rev-parse --git-path .pr-review-ok)\"  — then retry gh pr create. Note: any new commit invalidates the marker."}}
 EOF
 exit 0

--- a/src/app/pages/admin/AdminOrdersUI.tsx
+++ b/src/app/pages/admin/AdminOrdersUI.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Container, Select } from "@/design-system";
 import type { FeeModel } from "@/utils/money";
 import { getPaymentStatus } from "@/utils/payments";
 import { AdminOrderCard } from "./components/AdminOrderCard";
 import type { AppContext } from "@/worker";
 
-type Order = {
+export type Order = {
   id: string;
   userId: string | null;
   orderNumber: number;
@@ -59,10 +59,16 @@ export function AdminOrdersUI({ orders, ctx, csrfToken }: AdminOrdersUIProps) {
   const [paymentFilter, setPaymentFilter] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [dateFilter, setDateFilter] = useState('');
+  const [liveOrders, setLiveOrders] = useState(orders);
+  useEffect(() => setLiveOrders(orders), [orders]);
+
+  const handleOrderChange = (updated: Order) => {
+    setLiveOrders((prev) => prev.map((o) => (o.id === updated.id ? updated : o)));
+  };
 
   let filteredOrders = statusFilter === 'all'
-    ? orders
-    : orders.filter(o => o.status === statusFilter);
+    ? liveOrders
+    : liveOrders.filter(o => o.status === statusFilter);
 
   // Apply payment status filter
   if (paymentFilter !== 'all') {
@@ -95,10 +101,10 @@ export function AdminOrdersUI({ orders, ctx, csrfToken }: AdminOrdersUIProps) {
   }
 
   const counts = {
-    pending: orders.filter(o => o.status === 'pending').length,
-    confirmed: orders.filter(o => o.status === 'confirmed').length,
-    completed: orders.filter(o => o.status === 'completed').length,
-    cancelled: orders.filter(o => o.status === 'cancelled').length,
+    pending: liveOrders.filter(o => o.status === 'pending').length,
+    confirmed: liveOrders.filter(o => o.status === 'confirmed').length,
+    completed: liveOrders.filter(o => o.status === 'completed').length,
+    cancelled: liveOrders.filter(o => o.status === 'cancelled').length,
   };
 
   return (
@@ -126,7 +132,7 @@ export function AdminOrdersUI({ orders, ctx, csrfToken }: AdminOrdersUIProps) {
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
               options={[
-                { value: 'all', label: `All Orders (${orders.length})` },
+                { value: 'all', label: `All Orders (${liveOrders.length})` },
                 { value: 'pending', label: `Pending (${counts.pending})` },
                 { value: 'confirmed', label: `Confirmed (${counts.confirmed})` },
                 { value: 'completed', label: `Completed (${counts.completed})` },
@@ -294,6 +300,7 @@ export function AdminOrdersUI({ orders, ctx, csrfToken }: AdminOrdersUIProps) {
                 order={order}
                 ctx={ctx}
                 csrfToken={csrfToken}
+                onOrderChange={handleOrderChange}
               />
             ))}
           </div>

--- a/src/app/pages/admin/MarketConfigUI.tsx
+++ b/src/app/pages/admin/MarketConfigUI.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, useEffect } from "react";
 import { Button, QuickAction, AddEventButton, SectionHeader, MarketToggle } from "@/design-system";
 import { CompactMarketList, MarketFormModal } from "./components";
 import {
@@ -58,6 +58,36 @@ function isCancelled(market: Market): boolean {
   return !!market.cancelledAt;
 }
 
+type RawMarket = {
+  id: string;
+  name: string;
+  schedule: string;
+  subtitle: string | null;
+  locationDetails: string | null;
+  customerInfo: string | null;
+  active: boolean;
+  type: string;
+  expiresAt: Date | null;
+  catchPreview: string | null;
+  cancelledAt: Date | null;
+};
+
+function toUiMarket(m: RawMarket): Market {
+  return {
+    id: m.id,
+    name: m.name,
+    schedule: m.schedule,
+    subtitle: m.subtitle,
+    locationDetails: m.locationDetails,
+    customerInfo: m.customerInfo,
+    active: m.active,
+    type: m.type,
+    expiresAt: m.expiresAt?.toISOString() ?? null,
+    catchPreview: m.catchPreview,
+    cancelledAt: m.cancelledAt?.toISOString() ?? null,
+  };
+}
+
 function getInactiveBadge(market: Market): { label: string; className: string } {
   if (market.type === "popup" && isCancelled(market)) {
     return { label: "Cancelled", className: "badge--cancelled" };
@@ -91,6 +121,8 @@ function getInactiveBadge(market: Market): { label: string; className: string } 
  */
 export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; markets: Market[] }) {
   const [isPending, startTransition] = useTransition();
+  const [liveMarkets, setLiveMarkets] = useState(markets);
+  useEffect(() => setLiveMarkets(markets), [markets]);
 
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -114,7 +146,7 @@ export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; mark
   };
 
   const handleEditMarket = (marketId: string) => {
-    const market = markets.find((m) => m.id === marketId);
+    const market = liveMarkets.find((m) => m.id === marketId);
     setEditingMarket(market);
     setModalPresetType(market?.type === "popup" ? "popup" : "regular");
     setIsModalOpen(true);
@@ -134,9 +166,11 @@ export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; mark
   }) => {
     startTransition(async () => {
       if (editingMarket) {
-        await updateMarket(csrfToken, editingMarket.id, marketData);
+        const updated = await updateMarket(csrfToken, editingMarket.id, marketData);
+        setLiveMarkets((p) => p.map((m) => (m.id === updated.id ? toUiMarket(updated) : m)));
       } else {
-        await createMarket(csrfToken, marketData);
+        const created = await createMarket(csrfToken, marketData);
+        setLiveMarkets((p) => [...p, toUiMarket(created)]);
       }
       setIsModalOpen(false);
       setEditingMarket(undefined);
@@ -146,6 +180,7 @@ export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; mark
   const handleDeleteMarket = async (id: string) => {
     startTransition(async () => {
       await deleteMarket(csrfToken, id);
+      setLiveMarkets((p) => p.filter((m) => m.id !== id));
       setIsModalOpen(false);
       setEditingMarket(undefined);
     });
@@ -153,7 +188,8 @@ export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; mark
 
   const handleEndPopup = async (id: string) => {
     startTransition(async () => {
-      await endPopup(csrfToken, id);
+      const updated = await endPopup(csrfToken, id);
+      setLiveMarkets((p) => p.map((m) => (m.id === updated.id ? toUiMarket(updated) : m)));
       setIsModalOpen(false);
       setEditingMarket(undefined);
     });
@@ -161,7 +197,8 @@ export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; mark
 
   const handleCancelPopup = async (id: string) => {
     startTransition(async () => {
-      await cancelPopup(csrfToken, id);
+      const updated = await cancelPopup(csrfToken, id);
+      setLiveMarkets((p) => p.map((m) => (m.id === updated.id ? toUiMarket(updated) : m)));
       setIsModalOpen(false);
       setEditingMarket(undefined);
     });
@@ -174,22 +211,23 @@ export function MarketConfigUI({ csrfToken, markets }: { csrfToken: string; mark
 
   const handleToggleMarket = async (marketId: string) => {
     startTransition(async () => {
-      await toggleMarketActive(csrfToken, marketId);
+      const updated = await toggleMarketActive(csrfToken, marketId);
+      setLiveMarkets((p) => p.map((m) => (m.id === updated.id ? toUiMarket(updated) : m)));
     });
   };
 
   // Three-section grouping
-  const activePopups = markets.filter(
+  const activePopups = liveMarkets.filter(
     (m) => m.type === "popup" && m.active && !isExpired(m) && !isCancelled(m)
   );
-  const activeRegular = markets.filter(
+  const activeRegular = liveMarkets.filter(
     (m) => m.type !== "popup" && m.active
   );
-  const inactiveMarkets = markets.filter(
+  const inactiveMarkets = liveMarkets.filter(
     (m) => !m.active || (m.type === "popup" && (isExpired(m) || isCancelled(m)))
   );
 
-  const hasAnyMarkets = markets.length > 0;
+  const hasAnyMarkets = liveMarkets.length > 0;
 
   return (
     <div className="config-page">

--- a/src/app/pages/admin/components/AdminOrderCard.tsx
+++ b/src/app/pages/admin/components/AdminOrderCard.tsx
@@ -6,6 +6,7 @@ import { confirmOrder, updateConfirmedOrder, completeOrder, cancelOrderAdmin, ma
 import { getPaymentStatus, type PaymentStatus } from "@/utils/payments";
 import { formatCents, parseDollars, calculatePlatformFee, type FeeModel } from "@/utils/money";
 import type { AppContext } from "@/worker";
+import type { Order as AdminOrder } from "../AdminOrdersUI";
 
 type Order = {
   id: string;
@@ -51,9 +52,10 @@ interface AdminOrderCardProps {
   order: Order;
   ctx: AppContext;
   csrfToken: string;
+  onOrderChange: (order: AdminOrder) => void;
 }
 
-export function AdminOrderCard({ order, ctx, csrfToken }: AdminOrderCardProps) {
+export function AdminOrderCard({ order, ctx, csrfToken, onOrderChange }: AdminOrderCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [isPriceEditing, setIsPriceEditing] = useState(false);
   const [priceInput, setPriceInput] = useState(order.price ? String(order.price / 100) : '');
@@ -160,6 +162,7 @@ export function AdminOrderCard({ order, ctx, csrfToken }: AdminOrderCardProps) {
     startTransition(async () => {
       const result = await confirmOrder(csrfToken, order.id, priceInCents, adminNotes, depositOverride);
       if (result.success) {
+        onOrderChange(result.order);
         setIsEditing(false);
       } else {
         setErrorMessage(result.error || 'Failed to confirm order');
@@ -173,7 +176,9 @@ export function AdminOrderCard({ order, ctx, csrfToken }: AdminOrderCardProps) {
     setErrorMessage(null);
     startTransition(async () => {
       const result = await completeOrder(csrfToken, order.id);
-      if (!result.success) {
+      if (result.success) {
+        onOrderChange(result.order);
+      } else {
         setErrorMessage(result.error || 'Failed to complete order');
       }
     });
@@ -185,7 +190,9 @@ export function AdminOrderCard({ order, ctx, csrfToken }: AdminOrderCardProps) {
     setErrorMessage(null);
     startTransition(async () => {
       const result = await cancelOrderAdmin(csrfToken, order.id);
-      if (!result.success) {
+      if (result.success) {
+        onOrderChange(result.order);
+      } else {
         setErrorMessage(result.error || 'Failed to cancel order');
       }
     });
@@ -212,6 +219,7 @@ export function AdminOrderCard({ order, ctx, csrfToken }: AdminOrderCardProps) {
     startTransition(async () => {
       const result = await updateConfirmedOrder(csrfToken, order.id, priceInCents, adminNotes);
       if (result.success) {
+        onOrderChange(result.order);
         setIsPriceEditing(false);
       } else {
         setErrorMessage(result.error || 'Failed to update order');
@@ -239,6 +247,7 @@ export function AdminOrderCard({ order, ctx, csrfToken }: AdminOrderCardProps) {
     startTransition(async () => {
       const result = await markAsPaid(csrfToken, order.id, amountCents, paymentMethod, paymentNotes || undefined);
       if (result.success) {
+        onOrderChange(result.order);
         setShowPaymentModal(false);
       } else {
         setErrorMessage(result.error || 'Failed to record payment');

--- a/src/app/pages/admin/order-functions.ts
+++ b/src/app/pages/admin/order-functions.ts
@@ -10,13 +10,61 @@ import { sendOrderConfirmedEmail } from "@/utils/email";
 import { calculatePlatformFee, type FeeModel } from "@/utils/money";
 import { getStripe } from "@/utils/stripe";
 
+// Same include/select shape as AdminOrdersPage.tsx so mutation results can
+// replace the card's live state without a reload.
+function getOrderWithRelations(organizationId: string, orderId: string) {
+  return db.order.findFirst({
+    where: { id: orderId, organizationId },
+    include: {
+      user: {
+        select: {
+          username: true,
+          name: true,
+        },
+      },
+      organization: {
+        select: {
+          platformFeeBps: true,
+          feeModel: true,
+          defaultDepositBps: true,
+          stripeAccountId: true,
+          stripeOnboardingComplete: true,
+        },
+      },
+      payments: {
+        orderBy: { createdAt: 'desc' },
+      },
+    },
+  });
+}
+
+function serializeOrder(o: NonNullable<Awaited<ReturnType<typeof getOrderWithRelations>>>) {
+  return {
+    ...o,
+    organization: o.organization
+      ? { ...o.organization, feeModel: o.organization.feeModel as FeeModel }
+      : undefined,
+  };
+}
+
+type SerializedOrder = ReturnType<typeof serializeOrder>;
+type OrderMutationResult =
+  | { success: true; order: SerializedOrder }
+  | { success: false; error: string };
+
+async function refetchOrder(organizationId: string, orderId: string): Promise<OrderMutationResult> {
+  const refreshed = await getOrderWithRelations(organizationId, orderId);
+  if (!refreshed) return { success: false, error: "Order not found after update" };
+  return { success: true, order: serializeOrder(refreshed) };
+}
+
 export async function confirmOrder(
   csrfToken: string,
   orderId: string,
   price: number,
   adminNotes: string,
   depositOverride?: number | null,
-) {
+): Promise<OrderMutationResult> {
   requireCsrf(csrfToken);
 
   const { ctx, request } = requestInfo;
@@ -177,7 +225,7 @@ export async function confirmOrder(
     }
 
 
-    return { success: true };
+    return await refetchOrder(ctx.currentOrganization.id, orderId);
   } catch (error) {
     console.error('Failed to confirm order:', error);
     return { success: false, error: 'Failed to confirm order' };
@@ -189,7 +237,7 @@ export async function updateConfirmedOrder(
   orderId: string,
   newPrice: number,
   adminNotes: string,
-) {
+): Promise<OrderMutationResult> {
   requireCsrf(csrfToken);
 
   const { ctx } = requestInfo;
@@ -266,7 +314,7 @@ export async function updateConfirmedOrder(
       }
     }
 
-    return { success: true };
+    return await refetchOrder(ctx.currentOrganization.id, orderId);
   } catch (error) {
     console.error('Failed to update order:', error);
     return { success: false, error: 'Failed to update order' };
@@ -287,7 +335,7 @@ export const getPendingOrderCount = serverQuery(async (organizationId: string) =
   }
 });
 
-export async function completeOrder(csrfToken: string, orderId: string) {
+export async function completeOrder(csrfToken: string, orderId: string): Promise<OrderMutationResult> {
   requireCsrf(csrfToken);
 
   const { ctx } = requestInfo;
@@ -315,14 +363,14 @@ export async function completeOrder(csrfToken: string, orderId: string) {
     });
 
 
-    return { success: true };
+    return await refetchOrder(ctx.currentOrganization.id, orderId);
   } catch (error) {
     console.error('Failed to complete order:', error);
     return { success: false, error: 'Failed to complete order' };
   }
 }
 
-export async function cancelOrderAdmin(csrfToken: string, orderId: string) {
+export async function cancelOrderAdmin(csrfToken: string, orderId: string): Promise<OrderMutationResult> {
   requireCsrf(csrfToken);
 
   const { ctx } = requestInfo;
@@ -346,7 +394,7 @@ export async function cancelOrderAdmin(csrfToken: string, orderId: string) {
     });
 
 
-    return { success: true };
+    return await refetchOrder(ctx.currentOrganization.id, orderId);
   } catch (error) {
     console.error('Failed to cancel order:', error);
     return { success: false, error: 'Failed to cancel order' };
@@ -359,7 +407,7 @@ export async function markAsPaid(
   amount: number,
   method: string,
   notes?: string
-) {
+): Promise<OrderMutationResult> {
   requireCsrf(csrfToken);
 
   const { ctx } = requestInfo;
@@ -418,7 +466,7 @@ export async function markAsPaid(
       },
     });
 
-    return { success: true };
+    return await refetchOrder(ctx.currentOrganization.id, orderId);
   } catch (error) {
     console.error('Failed to mark as paid:', error);
     return { success: false, error: 'Failed to mark as paid' };


### PR DESCRIPTION
## Summary
Admin Market Settings and Orders pages required a manual reload to see the effect of any action — toggling a market, adding/editing/deleting, ending/cancelling a popup, and order confirm/complete/cancel/price-edit/mark-paid all looked like no-ops. Both pages now hold local state seeded from server props and update it from the server-returned row on each mutation, matching the pattern CatchUI already uses elsewhere in the app.

## What changed
- **MarketConfigUI**: added `liveMarkets` state (resynced from the `markets` prop via `useEffect`); all six mutation handlers (toggle/create/update/delete/endPopup/cancelPopup) now update it from the server-returned row via a new `toUiMarket()` helper that mirrors `MarketConfigPage.tsx`'s date-to-string serialization.
- **AdminOrdersUI / AdminOrderCard**: order state lifted to `AdminOrdersUI` (`liveOrders`, resynced via `useEffect`); filters/counts derive from it. `onOrderChange` passed down to `AdminOrderCard`, called on all 5 mutation successes.
- **order-functions.ts**: `confirmOrder`, `updateConfirmedOrder`, `completeOrder`, `cancelOrderAdmin`, `markAsPaid` now return `{ success, order }` via a shared `refetchOrder` helper (same include shape as `AdminOrdersPage.tsx` — user/organization/payments), instead of bare `{ success }`. Added explicit `Promise<OrderMutationResult>` return types so TS discriminates the union correctly.
- **(review) .claude/hooks/pre-pr-review-gate.sh**: synced the worktree-aware fix already merged to `main` (see #32) — this branch predated that merge and its copy of the hook was still using a marker path that can never exist inside a git worktree, which blocked PR creation entirely.

## How it was verified
- `pnpm run types` — clean.
- `pnpm run build` — clean.
- `pnpm run test` — 30/30 passing (8 files), no regressions.
- Independently reviewed the diff (not written by this session): confirmed `toUiMarket`/`refetchOrder` field shapes match the server components' own serialization exactly, confirmed all 5 order mutations and all 6 market mutations are wired to update local state, confirmed no other consumer of these lists (e.g. `PrintOrdersUI`, dashboard's `CompactMarketCard`) needed the same fix (out of scope — no mutations there).
- **Not tested**: manual browser click-through. This is a headless review session with no WebAuthn passkey available. Barrett should verify: Market toggle flips instantly; add/edit/delete/end/cancel reflect without reload and match a hard refresh; Orders confirm/complete/cancel/price-edit/mark-paid update the card, move it between status tabs, and update the count badges without reload.

## Review notes
No correctness issues found in the admin-refresh work itself. One unrelated infra blocker fixed: this branch's copy of the PR review gate hook predated the worktree-aware fix on `main`, so it could never find its own marker file and hard-blocked PR creation — synced that one file from `main` (already reviewed/merged there).

## Risks / rollback
- Client state can drift from the server if a mutation partially fails leaving inconsistent DB state; mitigated by using the server-returned row as source of truth plus a `useEffect` resync on prop change.
- Known accepted tradeoff (per branch decisions): local state means the server prop is no longer the single source of truth post-mutation — cross-row derived data won't recompute, and every future mutation needs matching client wiring. Revisit an RSC-refresh approach if this page grows more cross-row logic.
- Revert: `git revert 9b9fffd ebf56c3` for the admin-refresh work, or the whole PR merge commit.